### PR TITLE
Added proposed API docs for Grafana integration as OpenTSDB datasource

### DIFF
--- a/docs/opentsdb-subset.yaml
+++ b/docs/opentsdb-subset.yaml
@@ -1,0 +1,319 @@
+openapi: 3.0.0
+info:
+  title: Subset of OpenTSDB API supported by Ceres
+  description: Subset of OpenTSDB API supported by Ceres
+  version: 1.0.0
+servers:
+  - url: 'http://localhost:8080'
+paths:
+  /api/put:
+    description: Refer to http://opentsdb.net/docs/build/html/api_http/put.html
+    post:
+      parameters:
+        - in: header
+          name: X-Tenant
+          required: false
+          description: Optional/configurable, tenant originated observed metric value
+        - in: query
+          name: summary
+          required: false
+          schema:
+            type: boolean
+          description: |
+            When present with empty value or "true", repsonse includes summary of metrics written.
+        - in: query
+          name: details
+          schema:
+            type: boolean
+          description: |
+            When present with empty value or "true", response includes summary of metrics written
+            and errors.
+          required: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/Metric'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/Metric'
+            examples:
+              single:
+                value: |
+                  {
+                    "metric": "memory_free",
+                    "tags": {
+                      "tenant": "t-1",
+                      "os": "linux",
+                      "host": "h-1",
+                      "deployment": "prod"
+                    },
+                    "timestamp": 1604514466,
+                    "value": 123
+                  }
+              multi:
+                value: |
+                  [
+                    {
+                      "metric": "memory_free",
+                      "tags": {
+                        "tenant": "t-1",
+                        "os": "linux",
+                        "host": "h-1",
+                        "deployment": "prod"
+                      },
+                      "timestamp": 1604514466,
+                      "value": 123
+                    },
+                    {
+                      "metric": "cpu_usage",
+                      "tags": {
+                        "tenant": "t-2",
+                        "os": "linux",
+                        "host": "host-b",
+                        "deployment": "prod"
+                      },
+                      "timestamp": 1604514539,
+                      "value": 5.0
+                    }
+                  ]
+      responses:
+        204:
+          description: All data points were stored successfully
+        200:
+          description: |
+            When summary or details parameter is specified response includes the
+            corresponding content
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PutResponse'
+              examples:
+                summary:
+                  value: |
+                    {
+                      "failed": 0,
+                      "success": 5
+                    }
+                detailsWithError:
+                  value: |
+                    {
+                        "errors": [],
+                        "failed": 1,
+                        "success": 0
+                    }
+                detailsWithErrors:
+                  value: |
+                    {
+                        "errors": [
+                            {
+                                "datapoint": {
+                                    "metric": "sys.cpu.nice",
+                                    "timestamp": 1365465600,
+                                    "value": "NaN",
+                                    "tags": {
+                                        "host": "web01"
+                                    }
+                                },
+                                "error": "Unable to parse value to a number"
+                            }
+                        ],
+                        "failed": 1,
+                        "success": 0
+                    }
+  /api/suggest:
+    description: See http://opentsdb.net/docs/build/html/api_http/suggest.html
+    get:
+      parameters:
+        - name: type
+          in: query
+          required: true
+          schema:
+            type: string
+            enum:
+              - metrics
+              - tagk
+              - tagv
+        - name: q
+          in: query
+          required: false
+          description: Case-sensitive prefix to match
+        - name: max
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 25
+      responses:
+        200:
+          description: "Retrieval succeeded. Note: if nothing matched, then an empty array is returned"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+              example: |
+                [
+                  "resource",
+                  "resource_label"
+                ]
+  /api/search/lookup:
+    description: See http://opentsdb.net/docs/build/html/api_http/search/lookup.html
+    get:
+      parameters:
+        - name: m
+          in: query
+          description: Specifies the metric name or metric name and tag key to lookup
+          required: true
+          examples:
+            tagKeys:
+              value: "metric_name"
+            tagValues:
+              value: "metric_name{tagK=*}"
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            default: 25
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchLookupResponse'
+  /api/config/filters:
+    description: See http://opentsdb.net/docs/build/html/api_http/config/filters.html
+    get:
+      responses:
+        200:
+          description: Indicates which query filter types are currently supported
+          content:
+            application/json:
+              schema:
+                properties:
+                  literal_or:
+                    properties:
+                      examples:
+                        type: string
+                      description:
+                        type: string
+  /api/query:
+    description: See http://opentsdb.net/docs/build/html/api_http/query/index.html
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QueryRequest'
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryResponse'
+components:
+  schemas:
+    Metric:
+      properties:
+        metric:
+          required: true
+          type: string
+        timestamp:
+          required: true
+          type: integer
+          description: epoch timestamp in seconds
+        value:
+          required: true
+          type: number
+        tags:
+          required: true
+          additionalProperties:
+            type: string
+    PutResponse:
+      properties:
+        failed:
+          type: integer
+          required: true
+        success:
+          type: integer
+          required: true
+        errors:
+          required: false
+          type: array
+          items:
+            - properties:
+                datapoint:
+                  $ref: '#/components/schemas/Metric'
+                error:
+                  type: string
+    SearchLookupResponse:
+      properties:
+        results:
+          type: array
+          items:
+            properties:
+              tags:
+                description: |
+                  When lookup query supplied only a metric name, contains a tag key
+                  mapped to an empty string. When lookup query also included tagKey=*,
+                  then each value of the requested tag key is mapped.
+                additionalProperties:
+                  type: string
+    QueryRequest:
+      properties:
+        start:
+          $ref: '#/components/schemas/QueryTimestamp'
+        end:
+          $ref: '#/components/schemas/QueryTimestamp'
+        queries:
+          type: array
+          items:
+            properties:
+              metric:
+                type: string
+                required: true
+              downsample:
+                type: string
+                required: false
+                description: Formatted as <interval><unit>-<aggregator>
+              filters:
+                type: array
+                items:
+                  description: The type of each filter entry is currently ignored and assumed to be exact match
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - literal_or
+                    tagk:
+                      type: string
+                      required: true
+                    filter:
+                      type: string
+                      required: true
+      required:
+        - start
+    QueryResponse:
+      properties: {}
+    QueryTimestamp:
+      anyOf:
+        - type: string
+          description: ISO8601 timestamp
+          example: 2013-03-27T19:02:04Z
+        - type: string
+          description: Relative timestamp formatted as <amount><time unit>-ago
+          example: 1h-ago
+        - type: integer
+          description: Epoch milliseconds, when 13 or more digits
+          example: 1364410924000
+        - type: integer
+          description: Epoch seconds, when less than 13 digits
+          example: 1364410924

--- a/docs/opentsdb-subset.yaml
+++ b/docs/opentsdb-subset.yaml
@@ -97,7 +97,7 @@ paths:
                       "failed": 0,
                       "success": 5
                     }
-                detailsWithError:
+                detailsWithoutErrors:
                   value: |
                     {
                         "errors": [],


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/CERES-366

# What

In order to avoid developing a custom datasource to allow Racker support to use Grafana internally against Ceres, Ceres will support just enough of the OpenTSDB API to mimic it as a datasource.

# How

Investigated the opentsdb datasource source code to identify the API calls and variants used for request body, etc

- Source code: https://github.com/grafana/grafana/tree/master/public/app/plugins/datasource/opentsdb
- Main docs: https://grafana.com/docs/grafana/latest/datasources/opentsdb/

## How to test

The [raw URL of the OpenAPI yaml](https://raw.githubusercontent.com/racker/ceres/0759b8e6b5bbfb26c88ca2729e71ebe1fed33e20/docs/opentsdb-subset.yaml) can be entered into the "Explore" box at the top of the [Online Swagger demo UI](https://petstore.swagger.io/)
