### PR TITLE
Added support for various time formats in query api

### DIFF
--- a/src/main/java/com/rackspace/ceres/app/model/RelativeTime.java
+++ b/src/main/java/com/rackspace/ceres/app/model/RelativeTime.java
@@ -3,8 +3,14 @@ package com.rackspace.ceres.app.model;
 import java.time.temporal.ChronoUnit;
 
 public enum RelativeTime {
-  ms(ChronoUnit.MILLIS), s(ChronoUnit.SECONDS), m(ChronoUnit.MINUTES), h(ChronoUnit.HOURS),
-  d(ChronoUnit.DAYS), w(ChronoUnit.WEEKS), n(ChronoUnit.MONTHS), y(ChronoUnit.YEARS);
+  ms(ChronoUnit.MILLIS),
+  s(ChronoUnit.SECONDS),
+  m(ChronoUnit.MINUTES),
+  h(ChronoUnit.HOURS),
+  d(ChronoUnit.DAYS),
+  w(ChronoUnit.WEEKS),
+  n(ChronoUnit.MONTHS),
+  y(ChronoUnit.YEARS);
 
   ChronoUnit value;
 

--- a/src/main/java/com/rackspace/ceres/app/model/RelativeTime.java
+++ b/src/main/java/com/rackspace/ceres/app/model/RelativeTime.java
@@ -1,0 +1,18 @@
+package com.rackspace.ceres.app.model;
+
+import java.time.temporal.ChronoUnit;
+
+public enum RelativeTime {
+  ms(ChronoUnit.MILLIS), s(ChronoUnit.SECONDS), m(ChronoUnit.MINUTES), h(ChronoUnit.HOURS),
+  d(ChronoUnit.DAYS), w(ChronoUnit.WEEKS), n(ChronoUnit.MONTHS), y(ChronoUnit.YEARS);
+
+  ChronoUnit value;
+
+  RelativeTime(ChronoUnit unit) {
+    this.value = unit;
+  }
+
+  public ChronoUnit getValue() {
+    return value;
+  }
+}

--- a/src/main/java/com/rackspace/ceres/app/services/QueryService.java
+++ b/src/main/java/com/rackspace/ceres/app/services/QueryService.java
@@ -25,7 +25,6 @@ import com.rackspace.ceres.app.downsample.Aggregator;
 import com.rackspace.ceres.app.downsample.SingleValueSet;
 import com.rackspace.ceres.app.downsample.ValueSet;
 import com.rackspace.ceres.app.model.QueryResult;
-import com.rackspace.ceres.app.utils.DateTimeUtils;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.LinkedHashMap;
@@ -44,19 +43,16 @@ public class QueryService {
   private final MetadataService metadataService;
   private final DataTablesStatements dataTablesStatements;
   private final AppProperties appProperties;
-  private final DateTimeUtils dateTimeUtils;
 
   @Autowired
   public QueryService(ReactiveCqlTemplate cqlTemplate,
                       MetadataService metadataService,
                       DataTablesStatements dataTablesStatements,
-                      AppProperties appProperties,
-                      DateTimeUtils dateTimeUtils) {
+                      AppProperties appProperties) {
     this.cqlTemplate = cqlTemplate;
     this.metadataService = metadataService;
     this.dataTablesStatements = dataTablesStatements;
     this.appProperties = appProperties;
-    this.dateTimeUtils = dateTimeUtils;
   }
 
   public Flux<QueryResult> queryRaw(String tenant, String metricName,
@@ -131,43 +127,5 @@ public class QueryService {
                 .setTags(metricNameAndTags.getTags())
                 .setValues(values)
         );
-  }
-
-  /**
-   * Gets the start time based on the format in startTime.
-   *
-   * @param startTime
-   * @return
-   */
-  public Instant getStartTime(String startTime) {
-    if (dateTimeUtils.isValidInstantInstance(startTime)) {
-      return Instant.parse(startTime);
-    } else if (dateTimeUtils.isValidEpochMillis(startTime)) {
-      return Instant.ofEpochMilli(Long.parseLong(startTime));
-    } else if (dateTimeUtils.isValidEpochSeconds(startTime)) {
-      return Instant.ofEpochSecond(Long.parseLong(startTime));
-    } else {
-      return dateTimeUtils.getAbsoluteTimeFromRelativeTime(startTime);
-    }
-  }
-
-  /**
-   * Gets the end time based on the format in endTime.
-   *
-   * @param endTime
-   * @return
-   */
-  public Instant getEndTime(String endTime) {
-    if(endTime==null) {
-      return  Instant.now();
-    }
-    if (dateTimeUtils.isValidInstantInstance(endTime)) {
-      return Instant.parse(endTime);
-    } else if (dateTimeUtils.isValidEpochMillis(endTime)) {
-      return Instant.ofEpochMilli(Long.parseLong(endTime));
-    } else if (dateTimeUtils.isValidEpochSeconds(endTime)) {
-      return Instant.ofEpochSecond(Long.parseLong(endTime));
-    }
-    throw new IllegalArgumentException("End time format is invalid");
   }
 }

--- a/src/main/java/com/rackspace/ceres/app/services/QueryService.java
+++ b/src/main/java/com/rackspace/ceres/app/services/QueryService.java
@@ -25,6 +25,7 @@ import com.rackspace.ceres.app.downsample.Aggregator;
 import com.rackspace.ceres.app.downsample.SingleValueSet;
 import com.rackspace.ceres.app.downsample.ValueSet;
 import com.rackspace.ceres.app.model.QueryResult;
+import com.rackspace.ceres.app.utils.DateTimeUtils;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.LinkedHashMap;
@@ -43,16 +44,19 @@ public class QueryService {
   private final MetadataService metadataService;
   private final DataTablesStatements dataTablesStatements;
   private final AppProperties appProperties;
+  private final DateTimeUtils dateTimeUtils;
 
   @Autowired
   public QueryService(ReactiveCqlTemplate cqlTemplate,
                       MetadataService metadataService,
                       DataTablesStatements dataTablesStatements,
-                      AppProperties appProperties) {
+                      AppProperties appProperties,
+                      DateTimeUtils dateTimeUtils) {
     this.cqlTemplate = cqlTemplate;
     this.metadataService = metadataService;
     this.dataTablesStatements = dataTablesStatements;
     this.appProperties = appProperties;
+    this.dateTimeUtils = dateTimeUtils;
   }
 
   public Flux<QueryResult> queryRaw(String tenant, String metricName,
@@ -127,5 +131,43 @@ public class QueryService {
                 .setTags(metricNameAndTags.getTags())
                 .setValues(values)
         );
+  }
+
+  /**
+   * Gets the start time based on the format in startTime.
+   *
+   * @param startTime
+   * @return
+   */
+  public Instant getStartTime(String startTime) {
+    if (dateTimeUtils.isValidInstantInstance(startTime)) {
+      return Instant.parse(startTime);
+    } else if (dateTimeUtils.isValidEpochMillis(startTime)) {
+      return Instant.ofEpochMilli(Long.parseLong(startTime));
+    } else if (dateTimeUtils.isValidEpochSeconds(startTime)) {
+      return Instant.ofEpochSecond(Long.parseLong(startTime));
+    } else {
+      return dateTimeUtils.getAbsoluteTimeFromRelativeTime(startTime);
+    }
+  }
+
+  /**
+   * Gets the end time based on the format in endTime.
+   *
+   * @param endTime
+   * @return
+   */
+  public Instant getEndTime(String endTime) {
+    if(endTime==null) {
+      return  Instant.now();
+    }
+    if (dateTimeUtils.isValidInstantInstance(endTime)) {
+      return Instant.parse(endTime);
+    } else if (dateTimeUtils.isValidEpochMillis(endTime)) {
+      return Instant.ofEpochMilli(Long.parseLong(endTime));
+    } else if (dateTimeUtils.isValidEpochSeconds(endTime)) {
+      return Instant.ofEpochSecond(Long.parseLong(endTime));
+    }
+    throw new IllegalArgumentException("End time format is invalid");
   }
 }

--- a/src/main/java/com/rackspace/ceres/app/utils/DateTimeUtils.java
+++ b/src/main/java/com/rackspace/ceres/app/utils/DateTimeUtils.java
@@ -9,8 +9,8 @@ import java.util.regex.Pattern;
 public class DateTimeUtils {
 
   public static final String RELATIVE_TIME_PATTERN = "([0-9]+)(ms|s|m|h|d|w|n|y)-ago";
-  public static final String EPOCH_MILLIS_PATTERN = "^\\d{13,}$";
-  public static final String EPOCH_SECONDS_PATTERN = "^\\d{1,12}$";
+  public static final String EPOCH_MILLIS_PATTERN = "\\d{13,}";
+  public static final String EPOCH_SECONDS_PATTERN = "\\d{1,12}";
 
   /**
    * Gets the absolute Instant instance for relativeTime.
@@ -20,16 +20,12 @@ public class DateTimeUtils {
    */
   public static Instant getAbsoluteTimeFromRelativeTime(String relativeTime) {
     Matcher match = Pattern.compile(RELATIVE_TIME_PATTERN).matcher(relativeTime);
-    int timeValue = 0;
-    String timeUnit = null;
     if (match.matches()) {
-      timeValue = Integer.parseInt(match.group(1));
-      timeUnit = match.group(2);
-    }
-    if(timeUnit!=null && timeValue!=0)
-      return Instant.now().minus(timeValue, RelativeTime.valueOf(timeUnit).getValue());
-    else
+      return Instant.now()
+          .minus(Integer.parseInt(match.group(1)), RelativeTime.valueOf(match.group(2)).getValue());
+    } else {
       throw new IllegalArgumentException("Invalid relative time format");
+    }
   }
 
   /**
@@ -55,10 +51,7 @@ public class DateTimeUtils {
    */
   public static boolean isValidEpochMillis(String time) {
     Matcher match = Pattern.compile(DateTimeUtils.EPOCH_MILLIS_PATTERN).matcher(time);
-    if(match.matches()) {
-      return true;
-    }
-    return false;
+    return match.matches();
   }
 
   /**
@@ -69,10 +62,7 @@ public class DateTimeUtils {
    */
   public static boolean isValidEpochSeconds(String time) {
     Matcher match = Pattern.compile(DateTimeUtils.EPOCH_SECONDS_PATTERN).matcher(time);
-    if(match.matches()) {
-      return true;
-    }
-    return false;
+    return match.matches();
   }
 
   /**
@@ -82,8 +72,8 @@ public class DateTimeUtils {
    * @return
    */
   public static Instant parseInstant(String instant) {
-    if(instant==null) {
-      return  Instant.now();
+    if (instant == null) {
+      return Instant.now();
     }
     if (isValidInstantInstance(instant)) {
       return Instant.parse(instant);

--- a/src/main/java/com/rackspace/ceres/app/utils/DateTimeUtils.java
+++ b/src/main/java/com/rackspace/ceres/app/utils/DateTimeUtils.java
@@ -1,0 +1,79 @@
+package com.rackspace.ceres.app.utils;
+
+import com.rackspace.ceres.app.model.RelativeTime;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DateTimeUtils {
+
+  public static final String RELATIVE_TIME_PATTERN = "([0-9]+)(ms|s|m|h|d|w|n|y)-ago";
+  public static final String EPOCH_MILLIS_PATTERN = "^\\d{13,}$";
+  public static final String EPOCH_SECONDS_PATTERN = "^\\d{1,12}$";
+
+  /**
+   * Gets the absolute Instant instance for relativeTime.
+   *
+   * @param relativeTime
+   * @return
+   */
+  public Instant getAbsoluteTimeFromRelativeTime(String relativeTime) {
+    Matcher match = Pattern.compile(RELATIVE_TIME_PATTERN).matcher(relativeTime);
+    int timeValue = 0;
+    String timeUnit = null;
+    if (match.find()) {
+      timeValue = Integer.parseInt(match.group(1));
+      timeUnit = match.group(2);
+    }
+    if(timeUnit!=null && timeValue!=0)
+      return Instant.now().minus(timeValue, RelativeTime.valueOf(timeUnit).getValue());
+    else
+      throw new IllegalArgumentException("Start time format is invalid");
+  }
+
+  /**
+   * Checks if the string time is valid Instant in UTC.
+   *
+   * @param time
+   * @return
+   */
+  public boolean isValidInstantInstance(String time) {
+    try {
+      Instant.parse(time);
+      return true;
+    } catch (DateTimeParseException dateTimeParseException) {
+      return false;
+    }
+  }
+
+  /**
+   * Checks if the  time is valid epoch milli seconds.
+   *
+   * @param time
+   * @return
+   */
+  public boolean isValidEpochMillis(String time) {
+    Matcher match = Pattern.compile(DateTimeUtils.EPOCH_MILLIS_PATTERN).matcher(time);
+    if(match.find()) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Checks if the  time is valid epoch seconds.
+   *
+   * @param time
+   * @return
+   */
+  public boolean isValidEpochSeconds(String time) {
+    Matcher match = Pattern.compile(DateTimeUtils.EPOCH_SECONDS_PATTERN).matcher(time);
+    if(match.find()) {
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/main/java/com/rackspace/ceres/app/utils/DateTimeUtils.java
+++ b/src/main/java/com/rackspace/ceres/app/utils/DateTimeUtils.java
@@ -5,9 +5,7 @@ import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.springframework.stereotype.Service;
 
-@Service
 public class DateTimeUtils {
 
   public static final String RELATIVE_TIME_PATTERN = "([0-9]+)(ms|s|m|h|d|w|n|y)-ago";
@@ -20,18 +18,18 @@ public class DateTimeUtils {
    * @param relativeTime
    * @return
    */
-  public Instant getAbsoluteTimeFromRelativeTime(String relativeTime) {
+  public static Instant getAbsoluteTimeFromRelativeTime(String relativeTime) {
     Matcher match = Pattern.compile(RELATIVE_TIME_PATTERN).matcher(relativeTime);
     int timeValue = 0;
     String timeUnit = null;
-    if (match.find()) {
+    if (match.matches()) {
       timeValue = Integer.parseInt(match.group(1));
       timeUnit = match.group(2);
     }
     if(timeUnit!=null && timeValue!=0)
       return Instant.now().minus(timeValue, RelativeTime.valueOf(timeUnit).getValue());
     else
-      throw new IllegalArgumentException("Start time format is invalid");
+      throw new IllegalArgumentException("Invalid relative time format");
   }
 
   /**
@@ -40,7 +38,7 @@ public class DateTimeUtils {
    * @param time
    * @return
    */
-  public boolean isValidInstantInstance(String time) {
+  public static boolean isValidInstantInstance(String time) {
     try {
       Instant.parse(time);
       return true;
@@ -55,9 +53,9 @@ public class DateTimeUtils {
    * @param time
    * @return
    */
-  public boolean isValidEpochMillis(String time) {
+  public static boolean isValidEpochMillis(String time) {
     Matcher match = Pattern.compile(DateTimeUtils.EPOCH_MILLIS_PATTERN).matcher(time);
-    if(match.find()) {
+    if(match.matches()) {
       return true;
     }
     return false;
@@ -69,11 +67,32 @@ public class DateTimeUtils {
    * @param time
    * @return
    */
-  public boolean isValidEpochSeconds(String time) {
+  public static boolean isValidEpochSeconds(String time) {
     Matcher match = Pattern.compile(DateTimeUtils.EPOCH_SECONDS_PATTERN).matcher(time);
-    if(match.find()) {
+    if(match.matches()) {
       return true;
     }
     return false;
+  }
+
+  /**
+   * Gets the instance of Instant based on the format of argument.
+   *
+   * @param instant
+   * @return
+   */
+  public static Instant parseInstant(String instant) {
+    if(instant==null) {
+      return  Instant.now();
+    }
+    if (isValidInstantInstance(instant)) {
+      return Instant.parse(instant);
+    } else if (isValidEpochMillis(instant)) {
+      return Instant.ofEpochMilli(Long.parseLong(instant));
+    } else if (isValidEpochSeconds(instant)) {
+      return Instant.ofEpochSecond(Long.parseLong(instant));
+    } else {
+      return getAbsoluteTimeFromRelativeTime(instant);
+    }
   }
 }

--- a/src/main/java/com/rackspace/ceres/app/web/QueryController.java
+++ b/src/main/java/com/rackspace/ceres/app/web/QueryController.java
@@ -49,13 +49,15 @@ public class QueryController {
                                  @RequestParam(defaultValue = "raw") Aggregator aggregator,
                                  @RequestParam(required = false) Duration granularity,
                                  @RequestParam List<String> tag,
-                                 @RequestParam Instant start,
-                                 @RequestParam Instant end) {
+                                 @RequestParam String start,
+                                 @RequestParam(required = false) String end) {
 
+    Instant startTime = queryService.getStartTime(start);
+    Instant endTime = queryService.getEndTime(end);
     if (aggregator == null || Objects.equals(aggregator, Aggregator.raw)) {
       return queryService.queryRaw(tenant, metricName,
           convertPairsListToMap(tag),
-          start, end
+          startTime, endTime
       );
     } else {
       if (granularity == null) {
@@ -67,7 +69,7 @@ public class QueryController {
             aggregator,
             granularity,
             convertPairsListToMap(tag),
-            start, end
+            startTime, endTime
         );
       }
     }

--- a/src/main/java/com/rackspace/ceres/app/web/QueryController.java
+++ b/src/main/java/com/rackspace/ceres/app/web/QueryController.java
@@ -21,6 +21,7 @@ import static com.rackspace.ceres.app.web.TagListConverter.convertPairsListToMap
 import com.rackspace.ceres.app.downsample.Aggregator;
 import com.rackspace.ceres.app.model.QueryResult;
 import com.rackspace.ceres.app.services.QueryService;
+import com.rackspace.ceres.app.utils.DateTimeUtils;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -52,8 +53,8 @@ public class QueryController {
                                  @RequestParam String start,
                                  @RequestParam(required = false) String end) {
 
-    Instant startTime = queryService.getStartTime(start);
-    Instant endTime = queryService.getEndTime(end);
+    Instant startTime = DateTimeUtils.parseInstant(start);
+    Instant endTime = DateTimeUtils.parseInstant(end);
     if (aggregator == null || Objects.equals(aggregator, Aggregator.raw)) {
       return queryService.queryRaw(tenant, metricName,
           convertPairsListToMap(tag),

--- a/src/test/java/com/rackspace/ceres/app/utils/DateTimeUtilsTest.java
+++ b/src/test/java/com/rackspace/ceres/app/utils/DateTimeUtilsTest.java
@@ -57,7 +57,8 @@ public class DateTimeUtilsTest {
 
   @Test
   public void parseInstantTestWithNull() {
-    assertThat(DateTimeUtils.parseInstant(null)).isNotNull();
+    assertThat(Duration.between(DateTimeUtils.parseInstant(null), Instant.now()).getSeconds())
+        .isLessThanOrEqualTo(1);
   }
 
   @Test

--- a/src/test/java/com/rackspace/ceres/app/utils/DateTimeUtilsTest.java
+++ b/src/test/java/com/rackspace/ceres/app/utils/DateTimeUtilsTest.java
@@ -1,0 +1,85 @@
+package com.rackspace.ceres.app.utils;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
+
+import java.time.Instant;
+import org.junit.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class DateTimeUtilsTest {
+
+  @Test
+  public void getAbsoluteTimeFromRelativeTimeTest() {
+    Instant actual = DateTimeUtils.getAbsoluteTimeFromRelativeTime("1s-ago");
+    assertNotNull(actual);
+  }
+
+  @Test
+  public void getAbsoluteTimeFromRelativeTimeTest_Invalid() {
+    assertThatThrownBy(() -> DateTimeUtils.getAbsoluteTimeFromRelativeTime("1ss-ago"))
+        .isInstanceOf(IllegalArgumentException.class).hasMessage("Invalid relative time format");
+  }
+
+  @Test
+  public void isValidInstantInstanceTest() {
+    assertTrue(DateTimeUtils.isValidInstantInstance("2020-11-10T14:24:35Z"));
+  }
+
+  @Test
+  public void isValidInstantInstanceTest_Invalid() {
+    assertFalse(DateTimeUtils.isValidInstantInstance("13:03:15.454+0530Z"));
+  }
+
+  @Test
+  public void isValidEpochMillisTest() {
+    assertTrue(DateTimeUtils.isValidEpochMillis("1605094715000"));
+  }
+
+  @Test
+  public void isValidEpochMillisTest_Invalid() {
+    assertFalse(DateTimeUtils.isValidEpochMillis("1605094715"));
+  }
+
+  @Test
+  public void isValidEpochSecondsTest() {
+    assertTrue(DateTimeUtils.isValidEpochSeconds("1605094715"));
+  }
+
+  @Test
+  public void isValidEpochSecondsTest_Invalid() {
+    assertFalse(DateTimeUtils.isValidEpochSeconds("1605094715000"));
+  }
+
+  @Test
+  public void parseInstantTestWithNull() {
+    assertNotNull(DateTimeUtils.parseInstant(null));
+  }
+
+  @Test
+  public void parseInstantTestWithEpochMillis() {
+    assertEquals(DateTimeUtils.parseInstant("1605094715000"), Instant.ofEpochMilli(1605094715000l));
+  }
+
+  @Test
+  public void parseInstantTestWithEpochSeconds() {
+    assertEquals(DateTimeUtils.parseInstant("1605094715"), Instant.ofEpochMilli(1605094715l));
+  }
+
+  @Test
+  public void parseInstantTestWithUTCTime() {
+    assertEquals(DateTimeUtils.parseInstant("2020-11-10T14:24:35Z"),
+        Instant.parse("2020-11-10T14:24:35Z"));
+  }
+
+  @Test
+  public void parseInstantTestWithRelativeTime() {
+    assertNotNull(DateTimeUtils.parseInstant("1s-ago"));
+  }
+}

--- a/src/test/java/com/rackspace/ceres/app/utils/DateTimeUtilsTest.java
+++ b/src/test/java/com/rackspace/ceres/app/utils/DateTimeUtilsTest.java
@@ -1,24 +1,22 @@
 package com.rackspace.ceres.app.utils;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
 
+import java.time.Duration;
 import java.time.Instant;
-import org.junit.Test;
-import org.springframework.boot.test.context.SpringBootTest;
+import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
 @ActiveProfiles("test")
 public class DateTimeUtilsTest {
 
   @Test
   public void getAbsoluteTimeFromRelativeTimeTest() {
     Instant actual = DateTimeUtils.getAbsoluteTimeFromRelativeTime("1s-ago");
-    assertNotNull(actual);
+    Instant expected = Instant.now().minus(1, ChronoUnit.SECONDS);
+    assertThat(Duration.between(actual, expected).getSeconds()).isLessThanOrEqualTo(1);
   }
 
   @Test
@@ -29,57 +27,59 @@ public class DateTimeUtilsTest {
 
   @Test
   public void isValidInstantInstanceTest() {
-    assertTrue(DateTimeUtils.isValidInstantInstance("2020-11-10T14:24:35Z"));
+    assertThat(DateTimeUtils.isValidInstantInstance("2020-11-10T14:24:35Z")).isTrue();
   }
 
   @Test
   public void isValidInstantInstanceTest_Invalid() {
-    assertFalse(DateTimeUtils.isValidInstantInstance("13:03:15.454+0530Z"));
+    assertThat(DateTimeUtils.isValidInstantInstance("13:03:15.454+0530Z")).isFalse();
   }
 
   @Test
   public void isValidEpochMillisTest() {
-    assertTrue(DateTimeUtils.isValidEpochMillis("1605094715000"));
+    assertThat(DateTimeUtils.isValidEpochMillis("1605094715000")).isTrue();
   }
 
   @Test
   public void isValidEpochMillisTest_Invalid() {
-    assertFalse(DateTimeUtils.isValidEpochMillis("1605094715"));
+    assertThat(DateTimeUtils.isValidEpochMillis("1605094715")).isFalse();
   }
 
   @Test
   public void isValidEpochSecondsTest() {
-    assertTrue(DateTimeUtils.isValidEpochSeconds("1605094715"));
+    assertThat(DateTimeUtils.isValidEpochSeconds("1605094715")).isTrue();
   }
 
   @Test
   public void isValidEpochSecondsTest_Invalid() {
-    assertFalse(DateTimeUtils.isValidEpochSeconds("1605094715000"));
+    assertThat(DateTimeUtils.isValidEpochSeconds("1605094715000")).isFalse();
   }
 
   @Test
   public void parseInstantTestWithNull() {
-    assertNotNull(DateTimeUtils.parseInstant(null));
+    assertThat(DateTimeUtils.parseInstant(null)).isNotNull();
   }
 
   @Test
   public void parseInstantTestWithEpochMillis() {
-    assertEquals(DateTimeUtils.parseInstant("1605094715000"), Instant.ofEpochMilli(1605094715000l));
+    assertThat(DateTimeUtils.parseInstant("1605094715000"))
+        .isEqualTo(Instant.ofEpochMilli(1605094715000l));
   }
 
   @Test
   public void parseInstantTestWithEpochSeconds() {
-    assertEquals(DateTimeUtils.parseInstant("1605094715"), Instant.ofEpochMilli(1605094715l));
+    assertThat(DateTimeUtils.parseInstant("1605094715"))
+        .isEqualTo(Instant.ofEpochSecond(1605094715));
   }
 
   @Test
   public void parseInstantTestWithUTCTime() {
-    assertEquals(DateTimeUtils.parseInstant("2020-11-10T14:24:35Z"),
-        Instant.parse("2020-11-10T14:24:35Z"));
+    assertThat(DateTimeUtils.parseInstant("2020-11-10T14:24:35Z"))
+        .isEqualTo(Instant.parse("2020-11-10T14:24:35Z"));
   }
 
   @Test
   public void parseInstantTestWithRelativeTime() {
-    assertNotNull(DateTimeUtils.parseInstant("1s-ago"));
+    assertThat(DateTimeUtils.parseInstant("1s-ago")).isNotNull();
   }
 }


### PR DESCRIPTION
# Resolves
https://jira.rax.io/browse/CERES-370

# What
Need to add support for various time formats in query params of query api.

# How
Alter the query params to support different time formats.

## How to test
This can be tested via REST call or unit test cases.