### PR TITLE
Retry metadata insert on intermittent failures

### DIFF
--- a/src/main/java/com/rackspace/ceres/app/config/AppProperties.java
+++ b/src/main/java/com/rackspace/ceres/app/config/AppProperties.java
@@ -60,6 +60,11 @@ public class AppProperties {
   long seriesSetCacheSize = 5000;
 
   @NotNull
+  RetrySpec retryInsertMetadata = new RetrySpec()
+      .setMaxAttempts(5)
+      .setMinBackoff(Duration.ofMillis(100));
+
+  @NotNull
   RetrySpec retryInsertRaw = new RetrySpec()
       .setMaxAttempts(5)
       .setMinBackoff(Duration.ofMillis(100));

--- a/src/main/java/com/rackspace/ceres/app/config/DataTablesPopulator.java
+++ b/src/main/java/com/rackspace/ceres/app/config/DataTablesPopulator.java
@@ -22,6 +22,7 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.rackspace.ceres.app.services.DataTablesStatements;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
@@ -37,6 +38,7 @@ import org.springframework.data.cassandra.core.cql.session.init.KeyspacePopulato
 import org.springframework.data.cassandra.core.cql.session.init.ScriptException;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 /**
  * Handles the configuration-driven creation of data table schemas with corresponding table
@@ -73,6 +75,13 @@ public class DataTablesPopulator implements KeyspacePopulator {
         .concatWithValues(dataRawTableSpec(appProperties.getRawTtl()))
         .flatMap(spec -> createTable(spec, session))
         .subscribe();
+  }
+
+  public Mono<List<String>> render() {
+    return dataDownsampledTableSpecs()
+        .concatWithValues(dataRawTableSpec(appProperties.getRawTtl()))
+        .map(CreateTableCqlGenerator::toCql)
+        .collectList();
   }
 
   private Flux<CreateTableSpecification> dataDownsampledTableSpecs() {

--- a/src/main/java/com/rackspace/ceres/app/web/DdlController.java
+++ b/src/main/java/com/rackspace/ceres/app/web/DdlController.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.ceres.app.web;
+
+import com.rackspace.ceres.app.config.DataTablesPopulator;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/api")
+@Profile("dev")
+public class DdlController {
+
+  private final DataTablesPopulator dataTablesPopulator;
+
+  @Autowired
+  public DdlController(DataTablesPopulator dataTablesPopulator) {
+    this.dataTablesPopulator = dataTablesPopulator;
+  }
+
+  @GetMapping("/ddl/data")
+  public Mono<List<String>> getDataDdl() {
+    return dataTablesPopulator.render();
+  }
+}


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/CERES-373

# What

When the Cassandra coordinator node is overwhelmed during load testing the CQL operations will fail due to a timeout. All of the other insertion-query points are using reactive `retryWhen` operators, so...

# How

this adds the last spot that needed retry logic setup.

While doing load testing I needed to calculate the table options for varying retention intervals, so unrelated to the original issue I have also included a web endpoint to return the data table creation statements.

## How to test

This isn't an easy one to unit test at this point since a real cassandra instance is started via testcontainers. The test would need to induce a networking or backend failure somehow. Instead, later we can add some unit test cases that exercise MetadataService, but with a mock `CassandraTemplate` and mock `CqlTemplate` rather than the test container.