### PR TITLE
Added data table time partitioning

### DIFF
--- a/k8s/config-map.yaml
+++ b/k8s/config-map.yaml
@@ -17,16 +17,18 @@ data:
         granularities:
           - width: 5m
             ttl: 14d
+            partitionWidth: 6h
           - width: 1h
             ttl: 365d
+            partitionWidth: 24h
         partitions: 64
         partitions-mapping-file: /config/partitions.json
         # must be multiple of max granularity width
         time-slot-width: 1h
         processing-threads: 2
-      raw-ttl: 48h
-      tenant-tag: tenant_id
+      raw-ttl: 2d
       series-set-cache-size: 2000000
+      tenant-tag: tenant_id
     logging:
       level:
         com.rackspace.ceres.app: debug

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
 	<properties>
 		<java.version>14</java.version>
-		<testcontainers.version>1.15.0-rc2</testcontainers.version>
+		<testcontainers.version>1.15.0</testcontainers.version>
 		<image.prefix>racker/</image.prefix>
 	</properties>
 

--- a/src/main/java/com/rackspace/ceres/app/config/AppProperties.java
+++ b/src/main/java/com/rackspace/ceres/app/config/AppProperties.java
@@ -43,6 +43,23 @@ public class AppProperties {
   int dataTableGcGraceSeconds = 86400;
 
   /**
+   * The approximate number of compaction windows to declare on a newly created raw data table.
+   * Cassandra documentation recommends 20-30 windows:
+   * https://cassandra.apache.org/doc/latest/operating/compaction/twcs.html#twcs
+   */
+  @Min(20)
+  int rawCompactionWindows = 30;
+
+  /**
+   * The width of time slots used for partitioning data, which can reduce the number
+   * of Cassandra files that need to be scanned. It is best to set this to the same
+   * as <code>ceres.downsample.timeSlotWidth</code> or greater to ensure downsampling
+   * queries only need to consult one partition.
+   */
+  @NotNull
+  Duration rawPartitionWidth = Duration.ofHours(1);
+
+  /**
    * Identifies the tenant for ingest and query API calls. For ingest this header is optional
    * and instead <code>tenant-tag</code> will be used or the configured <code>default-tenant</code>
    * as a fallback.

--- a/src/main/java/com/rackspace/ceres/app/config/AppProperties.java
+++ b/src/main/java/com/rackspace/ceres/app/config/AppProperties.java
@@ -36,6 +36,13 @@ public class AppProperties {
   Duration rawTtl = Duration.ofHours(6);
 
   /**
+   * When initially creating the Cassandra data table schemas,
+   * this value will be used for the expired data garbage collection.
+   */
+  @Min(60)
+  int dataTableGcGraceSeconds = 86400;
+
+  /**
    * Identifies the tenant for ingest and query API calls. For ingest this header is optional
    * and instead <code>tenant-tag</code> will be used or the configured <code>default-tenant</code>
    * as a fallback.

--- a/src/main/java/com/rackspace/ceres/app/config/DataTablesPopulator.java
+++ b/src/main/java/com/rackspace/ceres/app/config/DataTablesPopulator.java
@@ -110,7 +110,8 @@ public class DataTablesPopulator implements KeyspacePopulator {
         .clusteredKeyColumn(DataTablesStatements.TIMESTAMP, DataTypes.TIMESTAMP)
         .column(DataTablesStatements.VALUE, DataTypes.DOUBLE)
         .with(DEFAULT_TIME_TO_LIVE, ttl.getSeconds(), false, false)
-        .with(TableOption.COMPACTION, compactionOptions(ttl));
+        .with(TableOption.COMPACTION, compactionOptions(ttl))
+        .with(TableOption.GC_GRACE_SECONDS, appProperties.getDataTableGcGraceSeconds());
   }
 
   private CreateTableSpecification dataRawTableSpec(Duration ttl) {
@@ -122,7 +123,8 @@ public class DataTablesPopulator implements KeyspacePopulator {
         .clusteredKeyColumn(DataTablesStatements.TIMESTAMP, DataTypes.TIMESTAMP)
         .column(DataTablesStatements.VALUE, DataTypes.DOUBLE)
         .with(DEFAULT_TIME_TO_LIVE, ttl.getSeconds(), false, false)
-        .with(TableOption.COMPACTION, compactionOptions(ttl));
+        .with(TableOption.COMPACTION, compactionOptions(ttl))
+        .with(TableOption.GC_GRACE_SECONDS, appProperties.getDataTableGcGraceSeconds());
   }
 
   private Map<Option,Object> compactionOptions(Duration ttl) {

--- a/src/main/java/com/rackspace/ceres/app/config/DataTablesPopulator.java
+++ b/src/main/java/com/rackspace/ceres/app/config/DataTablesPopulator.java
@@ -16,8 +16,6 @@
 
 package com.rackspace.ceres.app.config;
 
-import static com.rackspace.ceres.app.services.DataTablesStatements.TABLE_NAME_RAW;
-
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.rackspace.ceres.app.services.DataTablesStatements;
@@ -90,7 +88,8 @@ public class DataTablesPopulator implements KeyspacePopulator {
             downsampleProperties.getGranularities().stream()
                 .map(granularity -> dataDownsampledTableSpec(
                     granularity.getWidth(),
-                    granularity.getTtl()
+                    granularity.getTtl(),
+                    granularity.getPartitionWidth()
                 ))
         );
   }
@@ -100,12 +99,14 @@ public class DataTablesPopulator implements KeyspacePopulator {
     return session.executeReactive(CreateTableCqlGenerator.toCql(createTableSpec));
   }
 
-  private CreateTableSpecification dataDownsampledTableSpec(Duration width, Duration ttl) {
+  private CreateTableSpecification dataDownsampledTableSpec(Duration width, Duration ttl,
+                                                            Duration partitionWidth) {
     return CreateTableSpecification
-        .createTable(dataTablesStatements.tableNameDownsampled(width))
+        .createTable(dataTablesStatements.tableNameDownsampled(width, partitionWidth))
         .ifNotExists()
         .partitionKeyColumn(DataTablesStatements.TENANT, DataTypes.TEXT)
-        .partitionKeyColumn(DataTablesStatements.SERIES_SET_HASH, DataTypes.TEXT)
+        .partitionKeyColumn(DataTablesStatements.TIME_PARTITION_SLOT, DataTypes.TIMESTAMP)
+        .clusteredKeyColumn(DataTablesStatements.SERIES_SET_HASH, DataTypes.TEXT)
         .clusteredKeyColumn(DataTablesStatements.AGGREGATOR, DataTypes.TEXT)
         .clusteredKeyColumn(DataTablesStatements.TIMESTAMP, DataTypes.TIMESTAMP)
         .column(DataTablesStatements.VALUE, DataTypes.DOUBLE)
@@ -116,10 +117,11 @@ public class DataTablesPopulator implements KeyspacePopulator {
 
   private CreateTableSpecification dataRawTableSpec(Duration ttl) {
     return CreateTableSpecification
-        .createTable(TABLE_NAME_RAW)
+        .createTable(dataTablesStatements.tableNameRaw(appProperties.getRawPartitionWidth()))
         .ifNotExists()
         .partitionKeyColumn(DataTablesStatements.TENANT, DataTypes.TEXT)
-        .partitionKeyColumn(DataTablesStatements.SERIES_SET_HASH, DataTypes.TEXT)
+        .partitionKeyColumn(DataTablesStatements.TIME_PARTITION_SLOT, DataTypes.TIMESTAMP)
+        .clusteredKeyColumn(DataTablesStatements.SERIES_SET_HASH, DataTypes.TEXT)
         .clusteredKeyColumn(DataTablesStatements.TIMESTAMP, DataTypes.TIMESTAMP)
         .column(DataTablesStatements.VALUE, DataTypes.DOUBLE)
         .with(DEFAULT_TIME_TO_LIVE, ttl.getSeconds(), false, false)

--- a/src/main/java/com/rackspace/ceres/app/config/DataTablesPopulator.java
+++ b/src/main/java/com/rackspace/ceres/app/config/DataTablesPopulator.java
@@ -106,7 +106,7 @@ public class DataTablesPopulator implements KeyspacePopulator {
         .ifNotExists()
         .partitionKeyColumn(DataTablesStatements.TENANT, DataTypes.TEXT)
         .partitionKeyColumn(DataTablesStatements.SERIES_SET_HASH, DataTypes.TEXT)
-        .partitionKeyColumn(DataTablesStatements.AGGREGATOR, DataTypes.TEXT)
+        .clusteredKeyColumn(DataTablesStatements.AGGREGATOR, DataTypes.TEXT)
         .clusteredKeyColumn(DataTablesStatements.TIMESTAMP, DataTypes.TIMESTAMP)
         .column(DataTablesStatements.VALUE, DataTypes.DOUBLE)
         .with(DEFAULT_TIME_TO_LIVE, ttl.getSeconds(), false, false)

--- a/src/main/java/com/rackspace/ceres/app/config/DownsampleProperties.java
+++ b/src/main/java/com/rackspace/ceres/app/config/DownsampleProperties.java
@@ -113,5 +113,20 @@ public class DownsampleProperties {
     @NotNull
     @DurationFormat(DurationStyle.SIMPLE)
     Duration ttl;
+
+    /**
+     * The approximate number of compaction windows to declare on a newly created data table.
+     * Cassandra documentation recommends 20-30 windows:
+     * https://cassandra.apache.org/doc/latest/operating/compaction/twcs.html#twcs
+     */
+    @Min(20)
+    int compactionWindows = 30;
+
+    /**
+     * The width of time slots used for partitioning data, which can reduce the number
+     * of Cassandra files that need to be scanned.
+     */
+    @NotNull
+    Duration partitionWidth;
   }
 }

--- a/src/main/java/com/rackspace/ceres/app/services/MetadataService.java
+++ b/src/main/java/com/rackspace/ceres/app/services/MetadataService.java
@@ -32,7 +32,6 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import org.reactivestreams.Publisher;
@@ -193,7 +192,7 @@ public class MetadataService {
    * @param queryTags series-sets are located by and'ing these tag key-value pairs
    * @return the matching series-sets
    */
-  public Mono<Set<String>> locateSeriesSetHashes(String tenant, String metricName,
+  public Flux<String> locateSeriesSetHashes(String tenant, String metricName,
                                                  Map<String, String> queryTags) {
     return Flux.fromIterable(queryTags.entrySet())
         // find the series-sets for each query tag
@@ -211,7 +210,8 @@ public class MetadataService {
             results1.stream()
                 .filter(results2::contains)
                 .collect(Collectors.toSet())
-        );
+        )
+        .flatMapMany(Flux::fromIterable);
   }
 
 

--- a/src/main/java/com/rackspace/ceres/app/services/TimeSlotPartitioner.java
+++ b/src/main/java/com/rackspace/ceres/app/services/TimeSlotPartitioner.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.ceres.app.services;
+
+import com.rackspace.ceres.app.config.AppProperties;
+import com.rackspace.ceres.app.config.DownsampleProperties;
+import com.rackspace.ceres.app.config.DownsampleProperties.Granularity;
+import com.rackspace.ceres.app.downsample.TemporalNormalizer;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TimeSlotPartitioner {
+
+  private final Map<Duration, Entry> downsampleEntries;
+  private final Entry rawEntry;
+
+  private static class Entry {
+
+    final TemporalNormalizer normalizer;
+    final Duration partitionWidth;
+
+    private Entry(TemporalNormalizer normalizer, Duration partitionWidth) {
+      this.normalizer = normalizer;
+      this.partitionWidth = partitionWidth;
+    }
+  }
+
+  @Autowired
+  public TimeSlotPartitioner(AppProperties appProperties,
+                             DownsampleProperties downsampleProperties) {
+    rawEntry = new Entry(
+        new TemporalNormalizer(appProperties.getRawPartitionWidth()),
+        appProperties.getRawPartitionWidth()
+    );
+
+    if (downsampleProperties.getGranularities() != null) {
+      downsampleEntries = downsampleProperties.getGranularities().stream()
+          .collect(Collectors.toMap(
+              Granularity::getWidth,
+              granularity -> new Entry(
+                  new TemporalNormalizer(granularity.getPartitionWidth()),
+                  granularity.getPartitionWidth()
+              )
+          ));
+    }
+    else {
+      downsampleEntries = Map.of();
+    }
+  }
+
+  public Instant rawTimeSlot(Instant ts) {
+    return ts.with(rawEntry.normalizer);
+  }
+
+  public Instant downsampledTimeSlot(Instant ts, Duration granularity) {
+    final Entry entry = downsampleEntries.get(granularity);
+    if (entry != null) {
+      return ts.with(entry.normalizer);
+    }
+    throw new IllegalArgumentException("Unknown downsample granularity: " + granularity);
+  }
+
+  /**
+   * @param start start of range, inclusive
+   * @param end end of range, exclusive
+   * @param granularity the downsample granularity or null for raw
+   * @return the partition time slots
+   */
+  public Iterable<Instant> partitionsOverRange(Instant start, Instant end, Duration granularity) {
+    final Entry entry;
+    if (granularity == null) {
+      entry = rawEntry;
+    } else {
+      entry = downsampleEntries.get(granularity);
+      if (entry == null) {
+        throw new IllegalArgumentException("Unknown downsample granularity: " + granularity);
+      }
+    }
+
+    final List<Instant> partitions = new ArrayList<>();
+
+    Instant current = start.with(entry.normalizer);
+    partitions.add(current);
+
+    for (Instant next = current.plus(entry.partitionWidth);
+        // use isBefore since 'end' is exclusive
+        next.isBefore(end);
+        next = next.plus(entry.partitionWidth)
+    ) {
+      partitions.add(next);
+    }
+
+    return partitions;
+  }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -3,8 +3,10 @@ ceres:
     granularities:
       - width: 1m
         ttl: 12h
+        partitionWidth: 2h
       - width: 2m
         ttl: 1d
+        partitionWidth: 4h
     time-slot-width: 2m
     last-touch-delay: 1m
     downsample-process-period: 10s

--- a/src/test/java/com/rackspace/ceres/app/services/DataWriteServiceTest.java
+++ b/src/test/java/com/rackspace/ceres/app/services/DataWriteServiceTest.java
@@ -111,7 +111,7 @@ class DataWriteServiceTest {
 
       assertThat(metric).isNotNull();
 
-      assertViaQuery(tenantId, seriesSetHash, metric);
+      assertViaQuery(tenantId, Instant.parse("2020-09-12T18:00:00.0Z"), seriesSetHash, metric);
 
       verify(metadataService).storeMetadata(tenantId, seriesSetHash, metric.getMetric(),
           metric.getTags());
@@ -157,8 +157,8 @@ class DataWriteServiceTest {
           Tuples.of(tenant2, metric2)
       )).then().block();
 
-      assertViaQuery(tenant1, seriesSetHash1, metric1);
-      assertViaQuery(tenant2, seriesSetHash2, metric2);
+      assertViaQuery(tenant1, Instant.parse("2020-09-12T18:00:00.0Z"), seriesSetHash1, metric1);
+      assertViaQuery(tenant2, Instant.parse("2020-09-12T18:00:00.0Z"), seriesSetHash2, metric2);
 
       verify(metadataService).storeMetadata(tenant1, seriesSetHash1, metric1.getMetric(),
           metric1.getTags());
@@ -176,11 +176,14 @@ class DataWriteServiceTest {
       Assertions.fail("TODO");
     }
 
-    private void assertViaQuery(String tenant, String seriesSetHash, Metric metric) {
+    private void assertViaQuery(String tenant, Instant timeSlot, String seriesSetHash,
+                                Metric metric) {
       final List<Row> results = cqlTemplate.queryForRows(
-          "SELECT ts, value FROM data_raw"
-              + " WHERE tenant = ? AND series_set_hash = ?",
-          tenant, seriesSetHash
+          "SELECT ts, value FROM data_raw_p_pt1h"
+              + " WHERE tenant = ?"
+              + " AND time_slot = ?"
+              + " AND series_set_hash = ?",
+          tenant, timeSlot, seriesSetHash
       ).collectList().block();
 
       assertThat(results).isNotNull();

--- a/src/test/java/com/rackspace/ceres/app/services/TimeSlotPartitionerTest.java
+++ b/src/test/java/com/rackspace/ceres/app/services/TimeSlotPartitionerTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.ceres.app.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.rackspace.ceres.app.config.AppProperties;
+import com.rackspace.ceres.app.config.DownsampleProperties;
+import com.rackspace.ceres.app.config.DownsampleProperties.Granularity;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class TimeSlotPartitionerTest {
+
+  AppProperties appProperties = new AppProperties()
+      .setRawPartitionWidth(Duration.ofHours(1));
+  DownsampleProperties downsampleProperties = new DownsampleProperties()
+      .setGranularities(List.of(
+          new Granularity()
+              .setWidth(Duration.ofHours(1))
+              .setPartitionWidth(Duration.ofHours(24))
+      ));
+
+  @Test
+  void rawTimeSlot() {
+    final TimeSlotPartitioner partitioner = new TimeSlotPartitioner(
+        appProperties, downsampleProperties);
+
+    final Instant result = partitioner.rawTimeSlot(
+        Instant.parse("2007-12-03T10:15:30.00Z"));
+
+    assertThat(result).isEqualTo(Instant.parse("2007-12-03T10:00:00.00Z"));
+  }
+
+  @Nested
+  public class downsampledTimeSlot {
+    @Test
+    void success() {
+      final TimeSlotPartitioner partitioner = new TimeSlotPartitioner(
+          appProperties, downsampleProperties);
+
+      final Instant result = partitioner.downsampledTimeSlot(
+          Instant.parse("2007-12-03T10:15:30.00Z"),
+          Duration.ofHours(1)
+      );
+
+      assertThat(result).isEqualTo(Instant.parse("2007-12-03T00:00:00.00Z"));
+    }
+
+    @Test
+    void unknownGranularity() {
+      final TimeSlotPartitioner partitioner = new TimeSlotPartitioner(
+          appProperties, downsampleProperties);
+
+      assertThatThrownBy(() -> {
+        partitioner.downsampledTimeSlot(
+            Instant.parse("2007-12-03T10:15:30.00Z"),
+            Duration.ofMinutes(9)
+        );
+      })
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Nested
+  public class partitionsOverRange {
+    @Test
+    void rawWithinOneSlot() {
+      final TimeSlotPartitioner partitioner = new TimeSlotPartitioner(
+          appProperties, downsampleProperties);
+
+      final Iterable<Instant> results = partitioner.partitionsOverRange(
+          Instant.parse("2007-12-03T10:15:30.00Z"),
+          Instant.parse("2007-12-03T10:19:30.00Z"),
+          null
+      );
+
+      assertThat(results)
+          .containsExactlyInAnyOrder(Instant.parse("2007-12-03T10:00:00.00Z"));
+    }
+
+    @Test
+    void rawExactlyOneSlot() {
+      final TimeSlotPartitioner partitioner = new TimeSlotPartitioner(
+          appProperties, downsampleProperties);
+
+      final Iterable<Instant> results = partitioner.partitionsOverRange(
+          Instant.parse("2007-12-03T10:00:00.00Z"),
+          Instant.parse("2007-12-03T11:00:00.00Z"),
+          null
+      );
+
+      assertThat(results)
+          .containsExactlyInAnyOrder(Instant.parse("2007-12-03T10:00:00.00Z"));
+    }
+
+    @Test
+    void rawSpanningTwo() {
+      final TimeSlotPartitioner partitioner = new TimeSlotPartitioner(
+          appProperties, downsampleProperties);
+
+      final Iterable<Instant> results = partitioner.partitionsOverRange(
+          Instant.parse("2007-12-03T10:15:30.00Z"),
+          Instant.parse("2007-12-03T11:19:30.00Z"),
+          null
+      );
+
+      assertThat(results)
+          .containsExactlyInAnyOrder(
+              Instant.parse("2007-12-03T10:00:00.00Z"),
+              Instant.parse("2007-12-03T11:00:00.00Z")
+          );
+    }
+
+    @Test
+    void downsampleSpotCheck() {
+      final TimeSlotPartitioner partitioner = new TimeSlotPartitioner(
+          appProperties, downsampleProperties);
+
+      final Iterable<Instant> results = partitioner.partitionsOverRange(
+          Instant.parse("2007-12-02T10:15:30.00Z"),
+          Instant.parse("2007-12-04T11:19:30.00Z"),
+          Duration.ofHours(1)
+      );
+
+      assertThat(results)
+          .containsExactlyInAnyOrder(
+              Instant.parse("2007-12-02T00:00:00.00Z"),
+              Instant.parse("2007-12-03T00:00:00.00Z"),
+              Instant.parse("2007-12-04T00:00:00.00Z")
+          );
+    }
+
+    @Test
+    void unknownDownsampleGranularity() {
+      final TimeSlotPartitioner partitioner = new TimeSlotPartitioner(
+          appProperties, downsampleProperties);
+
+      assertThatThrownBy(() -> {
+        partitioner.partitionsOverRange(
+            Instant.parse("2007-12-02T10:15:30.00Z"),
+            Instant.parse("2007-12-04T11:19:30.00Z"),
+            Duration.ofMinutes(7)
+        );
+      })
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+}


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/CERES-375

# What

After about 6 days of continuous ingest the sstable count for the data raw table leveled out at about 60 sstables; however, at that point the read throughput of the cassandra nodes became saturated, as seen in the attached charts. Read latency grew and timeout conditions caused at least one node per downsample cycle to "crash" and restart.

Right now the data tables include tenant and series-set-hash in the partition key (PK) of the primary key. Cassandra uses a bloom filter to locate the sstable files that container a particular PK; however, without the timestamp being part of that all sstables eventually need to be scanned to locate the request time range for downsampling etc.

# How

This change shifts the series-set-hash to the clustering key (CK) of the primary key and introduces a configurable, normalized time slot column to the PK in order to optimize the use of the bloom filter when locating the sstables supporting a particular query, especially the downample queries.

Including the time slot in the PK along with the tenant still distributes the data sufficiently when someone is deploying Ceres on their own system with only a single tenant.

<How is the PR designed to solve the problem?>

## How to test

Unit tests have been updated/added and some manual testing of queries is needed.