### PR TITLE
spring boot version upgraded to 2.4.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.3.4.RELEASE</version>
+		<version>2.4.2</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.rackspace.ceres</groupId>


### PR DESCRIPTION
# Resolves

[CERES-386](https://jira.rax.io/browse/CERES-386)

# What

Spring boot version upgraded to 2.4.x

# How

Updated spring-boot-starter-parent version to 2.4.2

# Depends on

https://github.com/Rackspace-Segment-Support/umb-ceres-ingestor/pull/9
