### PR TITLE
Added support to truncate or exclude long tag values

### DIFF
--- a/src/main/java/com/rackspace/ceres/app/config/AppProperties.java
+++ b/src/main/java/com/rackspace/ceres/app/config/AppProperties.java
@@ -16,6 +16,7 @@
 
 package com.rackspace.ceres.app.config;
 
+import com.rackspace.ceres.app.model.TagFilter;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import javax.validation.constraints.Min;
@@ -102,4 +103,8 @@ public class AppProperties {
   RetrySpec retryQueryForDownsample = new RetrySpec()
       .setMaxAttempts(5)
       .setMinBackoff(Duration.ofMillis(100));
+
+  @NotNull TagFilter tagFilter = TagFilter.EXCLUDE;
+
+  @NotNull Integer tagValueLimit = 50;
 }

--- a/src/main/java/com/rackspace/ceres/app/model/TagFilter.java
+++ b/src/main/java/com/rackspace/ceres/app/model/TagFilter.java
@@ -1,0 +1,5 @@
+package com.rackspace.ceres.app.model;
+
+public enum TagFilter {
+  EXCLUDE, TRUNCATE
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -12,6 +12,8 @@ ceres:
     downsample-process-period: 10s
     partitions: 4
     partitions-to-process: 0-3
+  tag-filter: truncate
+  tag-value-limit: 50
 spring:
   data:
     cassandra:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -11,3 +11,5 @@ ceres:
       - width: 2m
         ttl: 1d
         partitionWidth: 4h
+  tag-filter: exclude
+  tag-value-limit: 10


### PR DESCRIPTION
# Resolves
https://jira.rax.io/browse/CERES-410

# What
Add support to truncate or exclude long tag values

# How
Added configurable parameters in application properties to support either exclusion or truncation of tag values which exceed the configurable limit.

## How to test
This can be tested via Rest call or unit test
