### PR TITLE
Added support to allow configurable exclusion of tag keys

### DIFF
--- a/src/main/java/com/rackspace/ceres/app/config/AppProperties.java
+++ b/src/main/java/com/rackspace/ceres/app/config/AppProperties.java
@@ -19,6 +19,7 @@ package com.rackspace.ceres.app.config;
 import com.rackspace.ceres.app.model.TagFilter;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
@@ -107,4 +108,6 @@ public class AppProperties {
   @NotNull TagFilter tagFilter = TagFilter.EXCLUDE;
 
   @NotNull Integer tagValueLimit = 50;
+
+  List<String> excludedTagKeys;
 }

--- a/src/main/java/com/rackspace/ceres/app/web/WriteController.java
+++ b/src/main/java/com/rackspace/ceres/app/web/WriteController.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.MultiValueMap;
+import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -57,6 +58,11 @@ public class WriteController {
   /**
    * NOTE: the path is <code>/put</code> even though it is a POST operation in order to be
    * API compatible with OpenTSDB.
+   *
+   * @param metrics
+   * @param allParams
+   * @param tenantHeader
+   * @return
    */
   @PostMapping("/put")
   public Mono<ResponseEntity<?>> putMetrics(@RequestBody @Validated Flux<Metric> metrics,
@@ -108,6 +114,9 @@ public class WriteController {
   }
 
   private void filterMetricTags(Metric metric) {
+    if(!ObjectUtils.isEmpty(appProperties.getExcludedTagKeys())) {
+      metric.getTags().entrySet().removeIf(entry -> appProperties.getExcludedTagKeys().contains(entry.getKey()));
+    }
     if (appProperties.getTagFilter() == TagFilter.EXCLUDE) {
       metric.getTags().entrySet()
           .removeIf(entry -> entry.getValue().length() >= appProperties.getTagValueLimit());

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -14,6 +14,7 @@ ceres:
     partitions-to-process: 0-3
   tag-filter: truncate
   tag-value-limit: 50
+  excluded-tag-keys: ["ip_address"]
 spring:
   data:
     cassandra:


### PR DESCRIPTION
# Resolves
https://jira.rax.io/browse/CERES-399

# What
Added feature to support configurable exclusion of tags keys.

# How
Added a list of tag keys in application properties to be excluded from storing in database.

## How to test
This can be tested via REST api or unit test case.