### PR TITLE
Rohit/ceres 427 get endpoint for suggest api

### DIFF
--- a/dev/Insomnia-workspace.yaml
+++ b/dev/Insomnia-workspace.yaml
@@ -3,6 +3,58 @@ __export_format: 4
 __export_date: 2021-02-19T08:59:59.174Z
 __export_source: insomnia.desktop.app:v2020.5.2
 resources:
+  - _id: req_0f668a996e1d4c66a17ee7c58f20d60d
+    parentId: fld_d7700ed860b740ce8c350442b50dbe56
+    modified: 1617276147028
+    created: 1617275121335
+    url: "{{ _.api_public }}/api/suggest"
+    name: Suggest API
+    description: ""
+    method: GET
+    body: {}
+    parameters:
+      - name: type
+        value: tagk
+        description: ""
+        id: pair_dfc424b0367a4c88b32e767466a20a05
+      - name: q
+        value: ho
+        description: ""
+        id: pair_2decedfd355442f3ba66d2bd30f9fccd
+      - name: max
+        value: "5"
+        description: ""
+        id: pair_528f32fde3ab416f85e96b4c717d0fbe
+        disabled: false
+    headers:
+      - name: X-Tenant
+        value: t-1
+        description: ""
+        id: pair_962d0050a76449a7bbf98564e030d289
+      - name: X-Auth-Token
+        value: "{{ _.auth_token }}"
+        description: ""
+        id: pair_1f38ca31ff2646a4955f864ac599b083
+    authentication: {}
+    metaSortKey: -1617275121335
+    isPrivate: false
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request
+  - _id: fld_d7700ed860b740ce8c350442b50dbe56
+    parentId: fld_76f005b356994fb6a17aa0229edd5089
+    modified: 1617275095666
+    created: 1617275095666
+    name: Opentsdb
+    description: ""
+    environment: {}
+    environmentPropertyOrder: null
+    metaSortKey: -1617275095666
+    _type: request_group
   - _id: req_ea9cca38d7924d218ca2b1d0831c93d7
     parentId: fld_48b9ea2fb7374017b2992b281547a65f
     modified: 1612946583590

--- a/src/main/java/com/rackspace/ceres/app/config/SuggestTypeEnumConverter.java
+++ b/src/main/java/com/rackspace/ceres/app/config/SuggestTypeEnumConverter.java
@@ -14,10 +14,16 @@
  * limitations under the License.
  */
 
-package com.rackspace.ceres.app.model;
+package com.rackspace.ceres.app.config;
 
-public enum SuggestType {
-  METRICS,
-  TAGK,
-  TAGV;
+import com.rackspace.ceres.app.model.SuggestType;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SuggestTypeEnumConverter implements Converter<String, SuggestType> {
+  @Override
+  public SuggestType convert(String s) {
+    return SuggestType.valueOf(s.toUpperCase());
+  }
 }

--- a/src/main/java/com/rackspace/ceres/app/model/SuggestType.java
+++ b/src/main/java/com/rackspace/ceres/app/model/SuggestType.java
@@ -1,0 +1,5 @@
+package com.rackspace.ceres.app.model;
+
+public enum SuggestType {
+  metrics, tagk, tagv;
+}

--- a/src/main/java/com/rackspace/ceres/app/services/SuggestApiService.java
+++ b/src/main/java/com/rackspace/ceres/app/services/SuggestApiService.java
@@ -1,0 +1,52 @@
+package com.rackspace.ceres.app.services;
+
+import java.util.List;
+import javax.xml.crypto.Data;
+import jnr.ffi.annotations.Meta;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.cassandra.core.cql.ReactiveCqlTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+public class SuggestApiService {
+
+  private final DataTablesStatements dataTablesStatements;
+  private final ReactiveCqlTemplate cqlTemplate;
+  private final MetadataService metadataService;
+
+  @Autowired
+  public SuggestApiService(DataTablesStatements dataTablesStatements, ReactiveCqlTemplate cqlTemplate,
+      MetadataService metadataService) {
+    this.dataTablesStatements = dataTablesStatements;
+    this.cqlTemplate = cqlTemplate;
+    this.metadataService = metadataService;
+  }
+
+  public Mono<List<String>> suggestTagKeys(String tenant, String tagK, int max) {
+    return metadataService.getMetricNames(tenant).flatMapMany(Flux::fromIterable)
+        .flatMap(metric -> metadataService.getTagKeys(tenant, metric).flatMapMany(Flux::fromIterable)
+        .filter(tagKey -> !StringUtils.hasText(tagK) || tagKey.startsWith(tagK)))
+        .limitRequest(max)
+        .collectList();
+    //return cqlTemplate.queryForFlux(cqlStatement, String.class, tenantId).filter(str -> str.startsWith(tagK)).distinct();
+  }
+
+  public Mono<List<String>> suggestMetricNames(String tenant, String metric, int max) {
+    return metadataService.getMetricNames(tenant).flatMapMany(Flux::fromIterable)
+        .filter(metricName -> !StringUtils.hasText(metric) || metricName.startsWith(metric))
+        .limitRequest(max)
+        .collectList();
+  }
+
+  public Mono<List<String>> suggestTagValues(String tenant, String tagV, int max) {
+    return metadataService.getMetricNames(tenant).flatMapMany(Flux::fromIterable)
+        .flatMap(metric -> metadataService.getTagKeys(tenant, metric).flatMapMany(Flux::fromIterable)
+        .flatMap(tagK -> metadataService.getTagValues(tenant, metric, tagK).flatMapMany(Flux::fromIterable)))
+        .filter(tagValue -> !StringUtils.hasText(tagV) || tagValue.startsWith(tagV))
+        .limitRequest(max)
+        .collectList();
+  }
+}

--- a/src/main/java/com/rackspace/ceres/app/services/SuggestApiService.java
+++ b/src/main/java/com/rackspace/ceres/app/services/SuggestApiService.java
@@ -34,7 +34,7 @@ public class SuggestApiService {
         .flatMap(metric -> metadataService.getTagKeys(tenant, metric).flatMapMany(Flux::fromIterable)
         .filter(tagKey -> !StringUtils.hasText(tagK) || tagKey.startsWith(tagK)))
         .distinct()
-        .limitRequest(max)
+        .take(max)
         .collectList();
   }
 
@@ -50,7 +50,7 @@ public class SuggestApiService {
   public Mono<List<String>> suggestMetricNames(String tenant, String metric, int max) {
     return metadataService.getMetricNames(tenant).flatMapMany(Flux::fromIterable)
         .filter(metricName -> !StringUtils.hasText(metric) || metricName.startsWith(metric))
-        .limitRequest(max)
+        .take(max)
         .collectList();
   }
 
@@ -69,7 +69,7 @@ public class SuggestApiService {
         .flatMap(tagK -> metadataService.getTagValues(tenant, metric, tagK).flatMapMany(Flux::fromIterable)))
         .filter(tagValue -> !StringUtils.hasText(tagV) || tagValue.startsWith(tagV))
         .distinct()
-        .limitRequest(max)
+        .take(max)
         .collectList();
   }
 }

--- a/src/main/java/com/rackspace/ceres/app/web/RestWebExceptionHandler.java
+++ b/src/main/java/com/rackspace/ceres/app/web/RestWebExceptionHandler.java
@@ -18,6 +18,7 @@ package com.rackspace.ceres.app.web;
 
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.TypeMismatchException;
 import org.springframework.boot.autoconfigure.web.ResourceProperties;
 import org.springframework.boot.autoconfigure.web.reactive.error.AbstractErrorWebExceptionHandler;
 import org.springframework.boot.web.error.ErrorAttributeOptions;
@@ -81,10 +82,9 @@ public class RestWebExceptionHandler extends
    * @return
    */
   private Mono<ServerResponse> respondWith(Map<String, Object> body, String exceptionClass) {
-    if (exceptionClass.equals(IllegalArgumentException.class.getName())) {
-      return respondWithBadRequest(body);
-    }
-    else if (exceptionClass.equals(ServerWebInputException.class.getName())) {
+    if (exceptionClass.equals(IllegalArgumentException.class.getName()) || exceptionClass
+        .equals(ServerWebInputException.class.getName()) || exceptionClass.equals(
+        TypeMismatchException.class.getName())) {
       return respondWithBadRequest(body);
     }
     return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR).body(BodyInserters.fromValue(

--- a/src/main/java/com/rackspace/ceres/app/web/SuggestApiController.java
+++ b/src/main/java/com/rackspace/ceres/app/web/SuggestApiController.java
@@ -22,8 +22,18 @@ public class SuggestApiController {
     this.suggestApiService = suggestApiService;
   }
 
+  /**
+   * This endpoint provides a means of implementing an auto-complete.
+   *
+   * @param tenant tenant of the customer
+   * @param type   This is the type of data we want to suggest. It can be anything from {@link
+   *               SuggestType}
+   * @param q      This is the text for which we have to suggest matching entries.
+   * @param max    Limit on number of results to return
+   * @return list of string containing the auto complete suggestions.
+   */
   @GetMapping
-  public Mono<List<String>> getSuggest(@RequestHeader("X-Tenant") String tenant,
+  public Mono<List<String>> getSuggestions(@RequestHeader("X-Tenant") String tenant,
       @RequestParam SuggestType type, @RequestParam(required = false) String q,
       @RequestParam(required = false, defaultValue = "25") int max) {
     if(type == SuggestType.tagk)

--- a/src/main/java/com/rackspace/ceres/app/web/SuggestApiController.java
+++ b/src/main/java/com/rackspace/ceres/app/web/SuggestApiController.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.rackspace.ceres.app.web;
 
 import com.rackspace.ceres.app.model.SuggestType;
@@ -36,10 +52,11 @@ public class SuggestApiController {
   public Mono<List<String>> getSuggestions(@RequestHeader("X-Tenant") String tenant,
       @RequestParam SuggestType type, @RequestParam(required = false) String q,
       @RequestParam(required = false, defaultValue = "25") int max) {
+
     return switch (type) {
-      case tagk -> suggestApiService.suggestTagKeys(tenant, q, max);
-      case tagv -> suggestApiService.suggestTagValues(tenant, q, max);
-      case metrics -> suggestApiService.suggestMetricNames(tenant, q, max);
+      case TAGK ->  suggestApiService.suggestTagKeys(tenant, q, max);
+      case TAGV -> suggestApiService.suggestTagValues(tenant, q, max);
+      case METRICS -> suggestApiService.suggestMetricNames(tenant, q, max);
     };
   }
 }

--- a/src/main/java/com/rackspace/ceres/app/web/SuggestApiController.java
+++ b/src/main/java/com/rackspace/ceres/app/web/SuggestApiController.java
@@ -36,11 +36,10 @@ public class SuggestApiController {
   public Mono<List<String>> getSuggestions(@RequestHeader("X-Tenant") String tenant,
       @RequestParam SuggestType type, @RequestParam(required = false) String q,
       @RequestParam(required = false, defaultValue = "25") int max) {
-    if(type == SuggestType.tagk)
-      return suggestApiService.suggestTagKeys(tenant, q, max);
-    else if(type == SuggestType.tagv)
-      return suggestApiService.suggestTagValues(tenant, q, max);
-    else
-      return suggestApiService.suggestMetricNames(tenant, q, max);
+    return switch (type) {
+      case tagk -> suggestApiService.suggestTagKeys(tenant, q, max);
+      case tagv -> suggestApiService.suggestTagValues(tenant, q, max);
+      case metrics -> suggestApiService.suggestMetricNames(tenant, q, max);
+    };
   }
 }

--- a/src/main/java/com/rackspace/ceres/app/web/SuggestApiController.java
+++ b/src/main/java/com/rackspace/ceres/app/web/SuggestApiController.java
@@ -1,0 +1,36 @@
+package com.rackspace.ceres.app.web;
+
+import com.rackspace.ceres.app.model.SuggestType;
+import com.rackspace.ceres.app.services.SuggestApiService;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/api/suggest")
+public class SuggestApiController {
+
+  private final SuggestApiService suggestApiService;
+
+  @Autowired
+  public SuggestApiController(SuggestApiService suggestApiService) {
+    this.suggestApiService = suggestApiService;
+  }
+
+  @GetMapping
+  public Mono<List<String>> getSuggest(@RequestHeader("X-Tenant") String tenant,
+      @RequestParam SuggestType type, @RequestParam(required = false) String q,
+      @RequestParam(required = false, defaultValue = "25") int max) {
+    if(type == SuggestType.tagk)
+      return suggestApiService.suggestTagKeys(tenant, q, max);
+    else if(type == SuggestType.tagv)
+      return suggestApiService.suggestTagValues(tenant, q, max);
+    else
+      return suggestApiService.suggestMetricNames(tenant, q, max);
+  }
+}

--- a/src/test/java/com/rackspace/ceres/app/services/SuggestApiServiceTest.java
+++ b/src/test/java/com/rackspace/ceres/app/services/SuggestApiServiceTest.java
@@ -43,6 +43,11 @@ public class SuggestApiServiceTest {
         .assertNext(metricNameList -> {
           Assertions.assertThat(metricNameList).isEmpty();
         }).verifyComplete();
+
+    StepVerifier.create(suggestApiService.suggestMetricNames("t-1", "cp", 0))
+        .assertNext(metricNameList -> {
+          Assertions.assertThat(metricNameList).isEmpty();
+        }).verifyComplete();
   }
 
   @Test

--- a/src/test/java/com/rackspace/ceres/app/services/SuggestApiServiceTest.java
+++ b/src/test/java/com/rackspace/ceres/app/services/SuggestApiServiceTest.java
@@ -1,0 +1,107 @@
+package com.rackspace.ceres.app.services;
+
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@SpringBootTest(classes = {SuggestApiService.class})
+public class SuggestApiServiceTest {
+
+  @Autowired
+  SuggestApiService suggestApiService;
+
+  @MockBean
+  MetadataService metadataService;
+
+  @Test
+  public void testSuggestMetricNames() {
+
+    List<String> metricNames = List.of("cpu_idle", "cpu_process", "process_state", "cpu_busy");
+    when(metadataService.getMetricNames("t-1")).thenReturn(Mono.just(metricNames));
+
+    StepVerifier.create(suggestApiService.suggestMetricNames("t-1", "cp", 10))
+        .assertNext(metricNameList -> {
+          Assertions.assertThat(metricNameList.size()).isEqualTo(3);
+          Assertions.assertThat(metricNameList).isEqualTo(List.of("cpu_idle", "cpu_process", "cpu_busy"));
+        }).verifyComplete();
+
+    //Test with the max limit
+    StepVerifier.create(suggestApiService.suggestMetricNames("t-1", "cp", 2))
+        .assertNext(metricNameList -> {
+          Assertions.assertThat(metricNameList.size()).isEqualTo(2);
+        }).verifyComplete();
+
+    //Test when metric doesn't match with any metric names
+    StepVerifier.create(suggestApiService.suggestMetricNames("t-1", "invalid", 10))
+        .assertNext(metricNameList -> {
+          Assertions.assertThat(metricNameList).isEmpty();
+        }).verifyComplete();
+  }
+
+  @Test
+  public void testSuggestTagKeys() {
+
+    List<String> metricNames = List.of("cpu_idle");
+    List<String> tagKeys = List.of("os", "osx");
+    when(metadataService.getMetricNames("t-1")).thenReturn(Mono.just(metricNames));
+    when(metadataService.getTagKeys("t-1", "cpu_idle")).thenReturn(Mono.just(tagKeys));
+
+    StepVerifier.create(suggestApiService.suggestTagKeys("t-1", "o", 10))
+        .assertNext(tagKeysList -> {
+          Assertions.assertThat(tagKeysList.size()).isEqualTo(2);
+          Assertions.assertThat(tagKeysList).isEqualTo(List.of("os", "osx"));
+        }).verifyComplete();
+
+    //Test with the max limit
+    StepVerifier.create(suggestApiService.suggestTagKeys("t-1", "o", 1))
+        .assertNext(tagKeysList -> {
+          Assertions.assertThat(tagKeysList.size()).isEqualTo(1);
+        }).verifyComplete();
+
+    //Test when metric doesn't match with any tag keys
+    StepVerifier.create(suggestApiService.suggestMetricNames("t-1", "invalid", 10))
+        .assertNext(tagKeysList -> {
+          Assertions.assertThat(tagKeysList).isEmpty();
+        }).verifyComplete();
+  }
+
+  @Test
+  public void testSuggestTagValues() {
+
+    List<String> metricNames = List.of("cpu_idle");
+    List<String> tagKeys = List.of("os", "osx");
+    List<String> tagValues1 = List.of("windows" , "linux", "linA");
+    List<String> tagValues2 = List.of("macos" , "linux", "linB");
+
+    when(metadataService.getMetricNames("t-1")).thenReturn(Mono.just(metricNames));
+    when(metadataService.getTagKeys("t-1", "cpu_idle")).thenReturn(Mono.just(tagKeys));
+    when(metadataService.getTagValues("t-1", "cpu_idle", "os")).thenReturn(Mono.just(tagValues1));
+    when(metadataService.getTagValues("t-1", "cpu_idle", "osx")).thenReturn(Mono.just(tagValues2));
+
+    StepVerifier.create(suggestApiService.suggestTagValues("t-1", "lin", 10))
+        .assertNext(tagValuesList -> {
+          Assertions.assertThat(tagValuesList.size()).isEqualTo(3);
+          Assertions.assertThat(tagValuesList).isEqualTo(List.of("linux", "linA", "linB"));
+        }).verifyComplete();
+
+    //Test with the max limit
+    StepVerifier.create(suggestApiService.suggestTagValues("t-1", "lin", 2))
+        .assertNext(tagKeysList -> {
+          Assertions.assertThat(tagKeysList.size()).isEqualTo(2);
+        }).verifyComplete();
+
+    //Test when metric doesn't match with any tag values
+    StepVerifier.create(suggestApiService.suggestTagValues("t-1", "invalid", 10))
+        .assertNext(tagKeysList -> {
+          Assertions.assertThat(tagKeysList).isEmpty();
+        }).verifyComplete();
+  }
+
+}

--- a/src/test/java/com/rackspace/ceres/app/web/SuggestApiControllerTest.java
+++ b/src/test/java/com/rackspace/ceres/app/web/SuggestApiControllerTest.java
@@ -3,6 +3,7 @@ package com.rackspace.ceres.app.web;
 import static org.mockito.Mockito.when;
 
 import com.rackspace.ceres.app.services.SuggestApiService;
+import java.util.Collections;
 import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -75,6 +76,35 @@ public class SuggestApiControllerTest {
         .queryParam("q", "h-")
         .queryParam("max", 10)
         .build()).header("X-Tenant", "t-1")
+        .exchange()
+        .expectStatus().isBadRequest();
+  }
+
+  @Test
+  public void testGetSuggestionsMax0() {
+    when(suggestApiService.suggestTagValues("t-1", "h-", 0))
+        .thenReturn(Mono.just(Collections.emptyList()));
+
+    webTestClient.get().uri(uriBuilder -> uriBuilder.path("/api/suggest")
+        .queryParam("type", "tagv")
+        .queryParam("q", "h-")
+        .queryParam("max", 0)
+        .build()).header("X-Tenant", "t-1")
+        .exchange()
+        .expectStatus().isOk().expectBody(List.class)
+        .isEqualTo(Collections.emptyList());
+  }
+
+  @Test
+  public void testGetSuggestionsTenantHeaderMissing() {
+    when(suggestApiService.suggestTagValues("t-1", "h-", 0))
+        .thenReturn(Mono.just(Collections.emptyList()));
+
+    webTestClient.get().uri(uriBuilder -> uriBuilder.path("/api/suggest")
+        .queryParam("type", "tagv")
+        .queryParam("q", "h-")
+        .queryParam("max", 10)
+        .build())
         .exchange()
         .expectStatus().isBadRequest();
   }

--- a/src/test/java/com/rackspace/ceres/app/web/SuggestApiControllerTest.java
+++ b/src/test/java/com/rackspace/ceres/app/web/SuggestApiControllerTest.java
@@ -1,0 +1,81 @@
+package com.rackspace.ceres.app.web;
+
+import static org.mockito.Mockito.when;
+
+import com.rackspace.ceres.app.services.SuggestApiService;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
+
+@ActiveProfiles(profiles = {"test"})
+@WebFluxTest(SuggestApiController.class)
+public class SuggestApiControllerTest {
+
+  @MockBean
+  SuggestApiService suggestApiService;
+
+  @Autowired
+  WebTestClient webTestClient;
+
+  @Test
+  public void testGetSuggestionsMetricNames() {
+    when(suggestApiService.suggestMetricNames("t-1", "cpu", 10))
+        .thenReturn(Mono.just(List.of("cpu_idle", "cpu_busy")));
+
+    webTestClient.get().uri(uriBuilder -> uriBuilder.path("/api/suggest")
+        .queryParam("type", "metrics")
+        .queryParam("q", "cpu")
+        .queryParam("max", 10)
+        .build()).header("X-Tenant", "t-1")
+        .exchange()
+        .expectStatus().isOk().expectBody(List.class)
+        .value(val -> Assertions.assertThat(val).contains("cpu_idle", "cpu_busy"));
+  }
+
+  @Test
+  public void testGetSuggestionsTagKeys() {
+    when(suggestApiService.suggestTagKeys("t-1", "os", 10))
+        .thenReturn(Mono.just(List.of("os", "osx")));
+
+    webTestClient.get().uri(uriBuilder -> uriBuilder.path("/api/suggest")
+        .queryParam("type", "tagk")
+        .queryParam("q", "os")
+        .queryParam("max", 10)
+        .build()).header("X-Tenant", "t-1")
+        .exchange()
+        .expectStatus().isOk().expectBody(List.class)
+        .value(val -> Assertions.assertThat(val).contains("os", "osx"));
+  }
+
+  @Test
+  public void testGetSuggestionsTagValues() {
+    when(suggestApiService.suggestTagValues("t-1", "h-", 10))
+        .thenReturn(Mono.just(List.of("h-1", "h-2", "h-3")));
+
+    webTestClient.get().uri(uriBuilder -> uriBuilder.path("/api/suggest")
+        .queryParam("type", "tagv")
+        .queryParam("q", "h-")
+        .queryParam("max", 10)
+        .build()).header("X-Tenant", "t-1")
+        .exchange()
+        .expectStatus().isOk().expectBody(List.class)
+        .value(val -> Assertions.assertThat(val).contains("h-1", "h-2","h-3"));
+  }
+
+  @Test
+  public void testGetSuggestionsInvalidType() {
+    webTestClient.get().uri(uriBuilder -> uriBuilder.path("/api/suggest")
+        .queryParam("type", "invalid")
+        .queryParam("q", "h-")
+        .queryParam("max", 10)
+        .build()).header("X-Tenant", "t-1")
+        .exchange()
+        .expectStatus().isBadRequest();
+  }
+}

--- a/src/test/java/com/rackspace/ceres/app/web/SuggestApiControllerTest.java
+++ b/src/test/java/com/rackspace/ceres/app/web/SuggestApiControllerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.rackspace.ceres.app.web;
 
 import static org.mockito.Mockito.when;


### PR DESCRIPTION
# Resolves
https://jira.rax.io/browse/CERES-427

# What
Create a Get endpoint for /api/suggest that is compatible with opentsdb suggest api.

# How
Created a rest api for GET /api/suggest with opentsdb reference from :- http://opentsdb.net/docs/build/html/api_http/suggest.html

## How to test
This can be tested with Junit or via rest call.

# TODO
Need to add this endpoint to ceres-gateway. This will be completed as part of https://jira.rax.io/browse/CERES-439