### PR TITLE
Rajesh/CERES-396 Added the actuator endpoints to the QueryController.

### DIFF
--- a/src/main/java/com/rackspace/ceres/app/web/QueryController.java
+++ b/src/main/java/com/rackspace/ceres/app/web/QueryController.java
@@ -47,16 +47,16 @@ public class QueryController {
 
   private final QueryService queryService;
   private final DownsampleProperties downsampleProperties;
-  private final Counter aggregatorQueryCounter;
-  private final Counter noAggregatorQueryCounter;
+  private final Counter rawQueryCounter;
+  private final Counter downSampleQueryCounter;
 
   @Autowired
   public QueryController(QueryService queryService, DownsampleProperties downsampleProperties,
       MeterRegistry meterRegistry) {
     this.queryService = queryService;
     this.downsampleProperties = downsampleProperties;
-    noAggregatorQueryCounter = meterRegistry.counter("Ceres.QueryApi", "Query", "Without_Aggregator");
-    aggregatorQueryCounter = meterRegistry.counter("Ceres.QueryApi", "Query", "With_Aggregator");
+    rawQueryCounter = meterRegistry.counter("ceres.query", "type", "raw");
+    downSampleQueryCounter = meterRegistry.counter("ceres.query", "type", "downsample");
   }
 
   @GetMapping
@@ -71,7 +71,7 @@ public class QueryController {
     Instant endTime = DateTimeUtils.parseInstant(end);
 
     if (aggregator == null || Objects.equals(aggregator, Aggregator.raw)) {
-      noAggregatorQueryCounter.increment();
+      rawQueryCounter.increment();
       return queryService.queryRaw(tenantParam, metricName,
           convertPairsListToMap(tag),
           startTime, endTime
@@ -81,7 +81,7 @@ public class QueryController {
         granularity = DateTimeUtils
             .getGranularity(startTime, endTime, downsampleProperties.getGranularities());
       }
-      aggregatorQueryCounter.increment();
+      downSampleQueryCounter.increment();
       return queryService.queryDownsampled(tenantParam, metricName,
           aggregator,
           granularity,

--- a/src/test/java/com/rackspace/ceres/app/web/QueryControllerTest.java
+++ b/src/test/java/com/rackspace/ceres/app/web/QueryControllerTest.java
@@ -15,7 +15,6 @@ import com.rackspace.ceres.app.model.Metadata;
 import com.rackspace.ceres.app.model.QueryData;
 import com.rackspace.ceres.app.model.QueryResult;
 import com.rackspace.ceres.app.services.QueryService;
-import com.rackspace.ceres.app.web.QueryControllerTest.MeterRegistryConfig;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.cumulative.CumulativeCounter;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -28,9 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebFlux;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Flux;
@@ -39,7 +36,7 @@ import reactor.test.StepVerifier;
 @ActiveProfiles(profiles = {"test", "query"})
 @SpringBootTest(classes = {QueryController.class, AppProperties.class,
     RestWebExceptionHandler.class,
-    DownsampleProperties.class, MeterRegistryConfig.class})
+    DownsampleProperties.class, SimpleMeterRegistry.class})
 @AutoConfigureWebTestClient
 @AutoConfigureWebFlux
 public class QueryControllerTest {
@@ -202,14 +199,5 @@ public class QueryControllerTest {
         .jsonPath("$.status").isEqualTo(400);
 
     verifyNoInteractions(queryService);
-  }
-
-  @TestConfiguration
-  static class MeterRegistryConfig {
-
-    @Bean
-    public MeterRegistry meterRegistry() {
-      return new SimpleMeterRegistry();
-    }
   }
 }


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/CERES-396

# What

This Jira ticket adds an actuator meter for the query API with which it would be possible to see what time ranges users tend to query and then configure the downsample widths and retention accordingly.


## How to test

To verify this Jira start the Ceres application locally and make a request to http://localhost:8081/actuator/prometheus once the request is successful, one should be able to see the response with the following text.

Ceres_QueryApi_total{Query="With_Aggregator",} 0.0
Ceres_QueryApi_total{Query="Without_Aggregator",} 0.0
