### PR TITLE
fixed failing of testDeleteMetricsByTenantId

### DIFF
--- a/src/test/java/com/rackspace/ceres/app/services/MetricDeletionServiceTest.java
+++ b/src/test/java/com/rackspace/ceres/app/services/MetricDeletionServiceTest.java
@@ -86,6 +86,9 @@ public class MetricDeletionServiceTest {
     when(metadataService.locateSeriesSetHashes(anyString(), anyString(), any()))
         .thenReturn(Flux.just(seriesSetHash));
 
+    when(metadataService.getMetricNames(anyString()))
+        .thenReturn(Mono.just(List.of(metricName)));
+
     MetricNameAndTags metricNameAndTags = new MetricNameAndTags().setTags(tags).setMetricName(metricName);
     when(metadataService.resolveSeriesSetHash(anyString(), anyString()))
         .thenReturn(Mono.just(metricNameAndTags));


### PR DESCRIPTION
# Resolves

[CERES-453](https://jira.rax.io/browse/CERES-453)

# What

Failing of testDeleteMetricsByTenantId in MetricDeletionServiceTest

# How

mocking getMetricNames of MetadataService

## How to test

test cases added

