### PR TITLE
Removed default tenant from ingest api

### DIFF
--- a/src/main/java/com/rackspace/ceres/app/config/AppProperties.java
+++ b/src/main/java/com/rackspace/ceres/app/config/AppProperties.java
@@ -73,11 +73,6 @@ public class AppProperties {
    * column.
    */
   String tenantTag = "tenant";
-  /**
-   * When tenant header and tag is not present during ingest, then this value will be used as
-   * the default.
-   */
-  String defaultTenant = "default";
 
   /**
    * Maximum size of the cache that tracks series-sets that have been persisted into Cassandra.

--- a/src/main/java/com/rackspace/ceres/app/web/WriteController.java
+++ b/src/main/java/com/rackspace/ceres/app/web/WriteController.java
@@ -79,10 +79,6 @@ public class WriteController {
                 tenant = tenantHeader;
               } else {
                 tenant = metric.getTags().remove(appProperties.getTenantTag());
-
-                if (!StringUtils.hasText(tenant)) {
-                  tenant = appProperties.getDefaultTenant();
-                }
               }
 
               return Tuples.of(tenant, metric);

--- a/src/test/java/com/rackspace/ceres/app/web/WriteControllerTest.java
+++ b/src/test/java/com/rackspace/ceres/app/web/WriteControllerTest.java
@@ -50,26 +50,6 @@ public class WriteControllerTest {
   ArgumentCaptor<Flux<Tuple2<String, Metric>>> metrics;
 
   @Test
-  public void testPutMetrics() {
-
-    Metric metric = new Metric().setMetric("metricA").setTags(
-        Collections.singletonMap("os", "linux")).setTimestamp(Instant.now()).setValue(123);
-
-    when(dataWriteService.ingest(any())).thenReturn(Flux.just(metric));
-
-    webTestClient.post().uri("/api/put").body(Flux.just(metric), Metric.class).exchange()
-        .expectStatus().isNoContent();
-
-    verify(dataWriteService).ingest(metrics.capture());
-
-    //verify tenant is default when not present in header or tagsMap
-    StepVerifier.create(metrics.getValue()).expectNext(Tuples.of("default", metric))
-        .expectComplete().verify();
-
-    verifyNoMoreInteractions(dataWriteService);
-  }
-
-  @Test
   public void testPutMetrics_WithParams() {
 
     Metric metric = new Metric().setMetric("metricA").setTags(


### PR DESCRIPTION
# Resolves
https://jira.rax.io/browse/CERES-437

# What
Remove default value of tenant on ingestion

# How
Removed addition of default tenant when no tenant is present in ingest api.

# Why
No need to default the tenant as it will always be coming from ingestor