### PR TITLE
fixed issues with deletion of metrics from downsample table

### DIFF
--- a/src/test/java/com/rackspace/ceres/app/services/MetricDeletionServiceTest.java
+++ b/src/test/java/com/rackspace/ceres/app/services/MetricDeletionServiceTest.java
@@ -14,6 +14,7 @@ import com.rackspace.ceres.app.downsample.ValueSet;
 import com.rackspace.ceres.app.model.Metric;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -298,7 +299,8 @@ public class MetricDeletionServiceTest {
     deleteDataFromRawTable(tenantId, timeSlotPartitioner.rawTimeSlot(currentTime));
 
     metricDeletionService.deleteMetrics(tenantId, "", null,
-        Instant.now().minusSeconds(60), Instant.now()).then().block();
+        Instant.now().minus(5, ChronoUnit.MINUTES),
+        Instant.now().plus(5, ChronoUnit.MINUTES)).then().block();
 
     assertViaQuery(tenantId, timeSlotPartitioner.rawTimeSlot(currentTime), seriesSetHash,
         metricName);


### PR DESCRIPTION
# Resolves

[CERES-472](https://jira.rax.io/browse/CERES-472)

# What

fixed issues with deletion of metrics from downsample table by getting timeSlot on the basis of partitionWidth from granularity and its test case as well.

# How

query downsample tables with time slot based on startTime, endTime and partitionWidth

## How to test

added junit test cases

# Why

MetricDeletionService Test cases were failing
