### PR TITLE
Added new param to associate dedicate metrics support to cloud acct

### DIFF
--- a/src/main/java/com/rackspace/ceres/app/web/QueryController.java
+++ b/src/main/java/com/rackspace/ceres/app/web/QueryController.java
@@ -84,6 +84,7 @@ public class QueryController {
       @ApiIgnore @RequestHeader(value = "#{appProperties.tenantHeader}") String tenantHeader,
       @RequestParam(required = false) String metricName,
       @RequestParam(required = false) String metricGroup,
+      @RequestParam(required = false) String maskTenantId,
       @RequestParam(defaultValue = "raw") Aggregator aggregator,
       @RequestParam(required = false) Duration granularity,
       @RequestParam List<String> tag,
@@ -94,6 +95,10 @@ public class QueryController {
     Instant startTime = DateTimeUtils.parseInstant(start);
     Instant endTime = DateTimeUtils.parseInstant(end);
 
+    //TODO Need to remove this code as this is part of testing and demo purpose only.
+    if(maskTenantId != null) {
+      tenantHeader = maskTenantId;
+    }
     if (aggregator == null || Objects.equals(aggregator, Aggregator.raw)) {
         rawQueryCounter.increment();
         return queryService.queryRaw(tenantHeader, metricName, metricGroup,


### PR DESCRIPTION
# Resolves
https://jira.rax.io/browse/CERES-543

# What
We need to add support to associate dedicate metrics to cloud account.

# How
Added new request param `maskTenantId` which will mask the original tenant id and give the result. This is for only testing and demo purpose.

## How to test
This can be tested using rest apis.