### PR TITLE
Changed suggest api service to use new tags_data table

### DIFF
--- a/src/main/java/com/rackspace/ceres/app/services/MetadataService.java
+++ b/src/main/java/com/rackspace/ceres/app/services/MetadataService.java
@@ -87,6 +87,7 @@ public class MetadataService {
       "SELECT device FROM devices WHERE tenant = ?";
   private static final String GET_METRIC_NAMES_FROM_DEVICE_QUERY =
       "SELECT metric_names FROM devices WHERE tenant = ? AND device = ?";
+  private static final String GET_TAG_KEYS_OR_VALUES_FROM_TAGS_DATA = "SELECT data from tags_data where tenant = ? AND type = ?";
 
   @Autowired
   public MetadataService(ReactiveCqlTemplate cqlTemplate,
@@ -430,5 +431,20 @@ public class MetadataService {
   public Mono<List<String>> getMetricNamesFromDevice(String tenantHeader, String device) {
     return cqlTemplate.queryForRows(GET_METRIC_NAMES_FROM_DEVICE_QUERY, tenantHeader, device)
         .flatMap(row -> Flux.fromIterable(row.getSet("metric_names", String.class))).collectList();
+  }
+
+  /**
+   * This method is used to query data from tags_data table based on the SuggestType TAGK or TAGV.
+   *
+   * @param tenantId
+   * @param type
+   * @return
+   */
+  public Mono<List<String>> getTagKeysOrValuesForTenant(String tenantId, SuggestType type) {
+    return cqlTemplate.queryForFlux(GET_TAG_KEYS_OR_VALUES_FROM_TAGS_DATA,
+        String.class,
+        tenantId,
+        type.name()
+    ).collectList();
   }
 }

--- a/src/main/java/com/rackspace/ceres/app/services/SuggestApiService.java
+++ b/src/main/java/com/rackspace/ceres/app/services/SuggestApiService.java
@@ -1,5 +1,6 @@
 package com.rackspace.ceres.app.services;
 
+import com.rackspace.ceres.app.model.SuggestType;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -27,9 +28,8 @@ public class SuggestApiService {
    * @return
    */
   public Mono<List<String>> suggestTagKeys(String tenant, String tagK, int max) {
-    return metadataService.getMetricNames(tenant).flatMapMany(Flux::fromIterable)
-        .flatMap(metric -> metadataService.getTagKeys(tenant, metric).flatMapMany(Flux::fromIterable)
-        .filter(tagKey -> !StringUtils.hasText(tagK) || tagKey.startsWith(tagK)))
+    return metadataService.getTagKeysOrValuesForTenant(tenant, SuggestType.TAGK).flatMapMany(Flux::fromIterable)
+        .filter(tagValue -> !StringUtils.hasText(tagK) || tagValue.startsWith(tagK))
         .distinct()
         .take(max)
         .collectList();
@@ -61,9 +61,7 @@ public class SuggestApiService {
    * @return
    */
   public Mono<List<String>> suggestTagValues(String tenant, String tagV, int max) {
-    return metadataService.getMetricNames(tenant).flatMapMany(Flux::fromIterable)
-        .flatMap(metric -> metadataService.getTagKeys(tenant, metric).flatMapMany(Flux::fromIterable)
-        .flatMap(tagK -> metadataService.getTagValues(tenant, metric, tagK).flatMapMany(Flux::fromIterable)))
+    return metadataService.getTagKeysOrValuesForTenant(tenant, SuggestType.TAGV).flatMapMany(Flux::fromIterable)
         .filter(tagValue -> !StringUtils.hasText(tagV) || tagValue.startsWith(tagV))
         .distinct()
         .take(max)

--- a/src/test/java/com/rackspace/ceres/app/services/SuggestApiServiceTest.java
+++ b/src/test/java/com/rackspace/ceres/app/services/SuggestApiServiceTest.java
@@ -2,6 +2,7 @@ package com.rackspace.ceres.app.services;
 
 import static org.mockito.Mockito.when;
 
+import com.rackspace.ceres.app.model.SuggestType;
 import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -53,10 +54,8 @@ public class SuggestApiServiceTest {
   @Test
   public void testSuggestTagKeys() {
 
-    List<String> metricNames = List.of("cpu_idle");
     List<String> tagKeys = List.of("os", "osx");
-    when(metadataService.getMetricNames("t-1")).thenReturn(Mono.just(metricNames));
-    when(metadataService.getTagKeys("t-1", "cpu_idle")).thenReturn(Mono.just(tagKeys));
+    when(metadataService.getTagKeysOrValuesForTenant("t-1", SuggestType.TAGK)).thenReturn(Mono.just(tagKeys));
 
     StepVerifier.create(suggestApiService.suggestTagKeys("t-1", "o", 10))
         .assertNext(tagKeysList -> {
@@ -71,7 +70,7 @@ public class SuggestApiServiceTest {
         }).verifyComplete();
 
     //Test when metric doesn't match with any tag keys
-    StepVerifier.create(suggestApiService.suggestMetricNames("t-1", "invalid", 10))
+    StepVerifier.create(suggestApiService.suggestTagKeys("t-1", "invalid", 10))
         .assertNext(tagKeysList -> {
           Assertions.assertThat(tagKeysList).isEmpty();
         }).verifyComplete();
@@ -80,15 +79,9 @@ public class SuggestApiServiceTest {
   @Test
   public void testSuggestTagValues() {
 
-    List<String> metricNames = List.of("cpu_idle");
-    List<String> tagKeys = List.of("os", "osx");
-    List<String> tagValues1 = List.of("windows" , "linux", "linA");
-    List<String> tagValues2 = List.of("macos" , "linux", "linB");
+    List<String> tagValues1 = List.of("windows" , "linux", "linA", "linB");
 
-    when(metadataService.getMetricNames("t-1")).thenReturn(Mono.just(metricNames));
-    when(metadataService.getTagKeys("t-1", "cpu_idle")).thenReturn(Mono.just(tagKeys));
-    when(metadataService.getTagValues("t-1", "cpu_idle", "os")).thenReturn(Mono.just(tagValues1));
-    when(metadataService.getTagValues("t-1", "cpu_idle", "osx")).thenReturn(Mono.just(tagValues2));
+    when(metadataService.getTagKeysOrValuesForTenant("t-1", SuggestType.TAGV)).thenReturn(Mono.just(tagValues1));
 
     StepVerifier.create(suggestApiService.suggestTagValues("t-1", "lin", 10))
         .assertNext(tagValuesList -> {


### PR DESCRIPTION
# Resolves
https://jira.rax.io/browse/CERES-565

# What
We need to update suggest api service to use the new tags_data table so that searching for tag keys and tag values for a tenant can be done faster.

# How
Added a method in metadata service layer to query data from tags_data table.

## How to test
Updated unit test cases to test the same.