### PR TITLE
CERES-641: adding timer metric to capture overall metrics ingestion latency

### DIFF
--- a/src/test/java/com/rackspace/ceres/app/services/DataWriteServiceTest.java
+++ b/src/test/java/com/rackspace/ceres/app/services/DataWriteServiceTest.java
@@ -155,7 +155,7 @@ class DataWriteServiceTest {
           tenantId, resource, metric.getMetric(), metric.getTimestamp().toString());
 
       verifyNoMoreInteractions(metadataService, downsampleTrackingService);
-      assertThat(meterRegistry.get("ingest.latency").timer().count()).isEqualTo(1);
+      assertThat(meterRegistry.get("ingest.latency").timer().count()).isGreaterThanOrEqualTo(1L);
     }
 
     @Test
@@ -222,7 +222,7 @@ class DataWriteServiceTest {
       verify(downsampleTrackingService).track(tenant2, seriesSetHash2, metric2.getTimestamp());
 
       verifyNoMoreInteractions(metadataService, downsampleTrackingService);
-      assertThat(meterRegistry.get("ingest.latency").timer().count()).isEqualTo(2);
+      assertThat(meterRegistry.get("ingest.latency").timer().count()).isGreaterThanOrEqualTo(2);
     }
 
     @Test

--- a/src/test/java/com/rackspace/ceres/app/services/DataWriteServiceTest.java
+++ b/src/test/java/com/rackspace/ceres/app/services/DataWriteServiceTest.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -70,6 +72,11 @@ class DataWriteServiceTest {
     CassandraContainer<?> cassandraContainer() {
       return cassandraContainer;
     }
+
+    @Bean
+    MeterRegistry meterRegistry() {
+      return new SimpleMeterRegistry();
+    }
   }
 
   static {
@@ -95,6 +102,9 @@ class DataWriteServiceTest {
 
   @Autowired
   ReactiveCqlTemplate cqlTemplate;
+
+  @Autowired
+  MeterRegistry meterRegistry;
 
   @Nested
   @NestedTestConfiguration(value = EnclosingConfiguration.OVERRIDE)
@@ -145,6 +155,7 @@ class DataWriteServiceTest {
           tenantId, resource, metric.getMetric(), metric.getTimestamp().toString());
 
       verifyNoMoreInteractions(metadataService, downsampleTrackingService);
+      assertThat(meterRegistry.get("ingest.latency").timer().count()).isEqualTo(1);
     }
 
     @Test
@@ -211,6 +222,7 @@ class DataWriteServiceTest {
       verify(downsampleTrackingService).track(tenant2, seriesSetHash2, metric2.getTimestamp());
 
       verifyNoMoreInteractions(metadataService, downsampleTrackingService);
+      assertThat(meterRegistry.get("ingest.latency").timer().count()).isEqualTo(2);
     }
 
     @Test


### PR DESCRIPTION

# Resolves

https://rackspace.atlassian.net/browse/CERES-641

# What

Publish Ingest Latency metrics

# How

Publish timer metric using metric timestamp and current instant timestamp

## How to test

Must be tested in DEV environment

Local environment test+Grafana for test metrics ingestion
<img width="1429" alt="Screen Shot 2021-11-30 at 2 32 41 PM" src="https://user-images.githubusercontent.com/4536063/144130985-d5953afb-1573-45cb-ae54-e9bf64efad1f.png">
