### PR TITLE
introducing design decisions using adr-tools

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+docs/decisions

--- a/docs/decisions/0001-record-architecture-decisions.md
+++ b/docs/decisions/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2022-04-04
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).

--- a/docs/decisions/0002-store-per-environment-configuration-files-in-ceres-repo.md
+++ b/docs/decisions/0002-store-per-environment-configuration-files-in-ceres-repo.md
@@ -1,0 +1,40 @@
+# 2. Store Per Environment Configuration Files in Ceres Repo
+
+Date: 2022-04-04
+
+## Status
+
+Accepted
+
+triggers [3. Ensure Unit tests for Configuration Files](0003-ensure-unit-tests-for-configuration-files.md)
+
+## Context
+
+Ceres will be deployed to multiple environments. Each env requires its own configuration file to manage.
+We could store these configurations in separate repo or ceres repo, or repo with helm charts etc.
+
+
+## Decision
+
+- Keep the files in ceres repo so that they are convenient to devs for easy changes + PR.
+- Prefer yaml content in config map file instead of string value containing yaml
+    ```
+   * DO NOT *
+    application.yml: |-
+      ceres:
+        downsample:
+          
+  
+    * DO * 
+    application.yml:
+      ceres:
+        downsample:      
+    ```
+
+## Consequences
+
+- Easier for devs to change
+- Controlled through normal PRs process
+- Storing the config in repo hinders the ability to be a public repo because it expose sensitive values
+- Helps devs to visualize property values in staging/prod as they browse through code
+

--- a/docs/decisions/0003-ensure-unit-tests-for-configuration-files.md
+++ b/docs/decisions/0003-ensure-unit-tests-for-configuration-files.md
@@ -1,0 +1,24 @@
+# 3. Ensure Unit tests for Configuration Files
+
+Date: 2022-04-04
+
+## Status
+
+Accepted
+
+triggered by [2. Store Per Environment Configuration Files in Ceres Repo](0002-store-per-environment-configuration-files-in-ceres-repo.md)
+
+## Context
+
+Configuration files used for deployments needs to be valid to prevent runtime errors.
+
+## Decision
+
+Write unit tests that verifies the validity of each configuration file content
+Examples: 
+- If a property needs to be numeric, tests should cover it
+- downsample-process-period needs to be multiple of 16
+
+## Consequences
+
+Prevents bad releases due to invalid configuration settings


### PR DESCRIPTION
# Resolves

Design decision documentation toolset

# What

-Introduces Ceres CI/CD related design decisions discussed during engineering sync meetings
- adr-tools (https://github.com/npryce/adr-tools) is chosen to document design decisions
   ```
    git clone git@github.com:npryce/adr-tools.git
    export PATH=$PWD/adr-tools/src:$PATH
    cd to ceres project
    Add new document using adr-new "human readable decision title". Example below

    adr-new "Ensure Unit tests for Configuration Files" 
  ```

# Why

We need a record of design related decisions with related context for future documentation 

