### PR TITLE
CERES-872: use cache to avoid cassandra updates for device info and m…

### DIFF
--- a/src/test/java/com/rackspace/ceres/app/services/DataWriteServiceTest.java
+++ b/src/test/java/com/rackspace/ceres/app/services/DataWriteServiceTest.java
@@ -134,11 +134,7 @@ class DataWriteServiceTest {
       );
       final String seriesSetHash = seriesSetService.hash(metricName, tags);
 
-      when(metadataService.updateMetricGroupAddMetricName(any(), any(), any(), any()))
-          .thenReturn(Mono.empty());
-      when(metadataService.updateDeviceAddMetricName(any(), any(), any(), any()))
-          .thenReturn(Mono.empty());
-      when(metadataService.storeMetadata(any(), any(), any(), any())).thenReturn(Mono.empty());
+      when(metadataService.storeMetadata(any(), any(), any())).thenReturn(Mono.empty());
 
       when(ingestTrackingService.track(any(), anyString(), any()))
           .thenReturn(Mono.empty());
@@ -158,13 +154,8 @@ class DataWriteServiceTest {
       Instant metricQueryTime = metricTime.with(new TemporalNormalizer(Duration.ofHours(1)));
       assertViaQuery(tenantId, metricQueryTime, seriesSetHash, metric);
 
-      verify(metadataService).storeMetadata(tenantId, seriesSetHash, metric.getMetric(), metric.getTags());
+      verify(metadataService).storeMetadata(tenantId, seriesSetHash, metric);
       verify(ingestTrackingService).track(tenantId, seriesSetHash, metric.getTimestamp());
-      verify(metadataService).updateMetricGroupAddMetricName(
-          tenantId, metricGroup, metric.getMetric(), metric.getTimestamp().toString());
-      verify(metadataService).updateDeviceAddMetricName(
-          tenantId, resource, metric.getMetric(), metric.getTimestamp().toString());
-
       verifyNoMoreInteractions(metadataService, ingestTrackingService);
     }
 
@@ -189,11 +180,7 @@ class DataWriteServiceTest {
       final String seriesSetHash1 = seriesSetService.hash(metricName1, tags);
       final String seriesSetHash2 = seriesSetService.hash(metricName2, tags);
 
-      when(metadataService.updateMetricGroupAddMetricName(any(), any(), any(), any()))
-          .thenReturn(Mono.empty());
-      when(metadataService.updateDeviceAddMetricName(any(), any(), any(), any()))
-          .thenReturn(Mono.empty());
-      when(metadataService.storeMetadata(any(), any(), any(), any()))
+      when(metadataService.storeMetadata(any(), any(), any()))
           .thenReturn(Mono.empty());
 
       when(ingestTrackingService.track(any(), anyString(), any()))
@@ -220,19 +207,9 @@ class DataWriteServiceTest {
       assertViaQuery(tenant1, metricQueryTime, seriesSetHash1, metric1);
       assertViaQuery(tenant2, metricQueryTime, seriesSetHash2, metric2);
 
-      verify(metadataService).storeMetadata(tenant1, seriesSetHash1, metric1.getMetric(),
-          metric1.getTags());
-      verify(metadataService).storeMetadata(tenant2, seriesSetHash2, metric2.getMetric(),
-          metric2.getTags());
+      verify(metadataService).storeMetadata(tenant1, seriesSetHash1, metric1);
+      verify(metadataService).storeMetadata(tenant2, seriesSetHash2, metric2);
 
-      verify(metadataService).updateMetricGroupAddMetricName(
-          tenant1, metricGroup, metric1.getMetric(), metric1.getTimestamp().toString());
-      verify(metadataService).updateMetricGroupAddMetricName(
-          tenant2, metricGroup, metric2.getMetric(), metric2.getTimestamp().toString());
-      verify(metadataService).updateDeviceAddMetricName(
-          tenant1, resource, metric1.getMetric(), metric1.getTimestamp().toString());
-      verify(metadataService).updateDeviceAddMetricName(
-          tenant2, resource, metric2.getMetric(), metric2.getTimestamp().toString());
       verify(ingestTrackingService).track(tenant1, seriesSetHash1, metric1.getTimestamp());
       verify(ingestTrackingService).track(tenant2, seriesSetHash2, metric2.getTimestamp());
 

--- a/src/test/java/com/rackspace/ceres/app/services/MetadataServiceTest.java
+++ b/src/test/java/com/rackspace/ceres/app/services/MetadataServiceTest.java
@@ -220,7 +220,7 @@ class MetadataServiceTest {
     Mono.ignoreElements(
         metadataService.storeMetadata(
             tenantId,
-            unhashedSeriesSet(metricName, tags), metric.getMetric(), metric.getTags()
+            unhashedSeriesSet(metricName, tags), metric
         )
     )
         .block();

--- a/src/test/java/com/rackspace/ceres/app/services/QueryServiceTest.java
+++ b/src/test/java/com/rackspace/ceres/app/services/QueryServiceTest.java
@@ -143,7 +143,7 @@ class QueryServiceTest {
     when(ingestTrackingService.track(any(), anyString(), any()))
         .thenReturn(Mono.empty());
 
-    when(metadataService.storeMetadata(any(), any(), any(), any()))
+    when(metadataService.storeMetadata(any(), any(), any()))
         .thenReturn(Mono.empty());
 
     when(metadataService.locateSeriesSetHashes(anyString(), anyString(), any()))
@@ -199,7 +199,7 @@ class QueryServiceTest {
     when(ingestTrackingService.track(any(), anyString(), any()))
         .thenReturn(Mono.empty());
 
-    when(metadataService.storeMetadata(any(), any(), any(), any()))
+    when(metadataService.storeMetadata(any(), any(), any()))
         .thenReturn(Mono.empty());
 
     when(metadataService.locateSeriesSetHashes(anyString(), anyString(), any()))
@@ -253,7 +253,7 @@ class QueryServiceTest {
     when(ingestTrackingService.track(any(), anyString(), any()))
         .thenReturn(Mono.empty());
 
-    when(metadataService.storeMetadata(any(), any(), any(), any()))
+    when(metadataService.storeMetadata(any(), any(), any()))
         .thenReturn(Mono.empty());
 
     when(metadataService.updateMetricGroupAddMetricName(anyString(), anyString(), any(), any()))
@@ -300,7 +300,7 @@ class QueryServiceTest {
     final String seriesSetHash = seriesSetService
         .hash(metricName, tags);
 
-    when(metadataService.storeMetadata(any(), any(), any(), any()))
+    when(metadataService.storeMetadata(any(), any(), any()))
         .thenReturn(Mono.empty());
 
     when(metadataService.locateSeriesSetHashes(anyString(), anyString(), any()))
@@ -364,7 +364,7 @@ class QueryServiceTest {
     when(ingestTrackingService.track(any(), anyString(), any()))
         .thenReturn(Mono.empty());
 
-    when(metadataService.storeMetadata(any(), any(), any(), any()))
+    when(metadataService.storeMetadata(any(), any(), any()))
         .thenReturn(Mono.empty());
 
     when(metadataService.locateSeriesSetHashes(anyString(), anyString(), any()))


### PR DESCRIPTION
…etric group

# Resolves

[CERES-872](https://rackspace.atlassian.net/browse/CERES-872)

# What

Avoid redundant cassandra writes in device and metric group column families using Cache


# How

Refactored updateMetricGroupAddMetricName and updateDeviceAddMetricName method calls

Ceres ingestion already caches metadata for unique metric series ingested. Updating device and metric group column families can be pushed after cache check similar to other existing metadata updates. Update cassandra only if cache does not have the info.

## How to test

Unit tests and Dev

# Why

Avoid unnecessary cassandra writes. These changes shave off 90% calls related to device and metric group updates
Grafana observations of CPU and Writes/sec before and after change:
[Writes/Sec](https://ceres-grafana.dev.monplat.rackspace.net/d/9VfDrq97z/cassandra-overview?from=1656000894415&orgId=1&to=1656011678052&viewPanel=5) vs [CPU](https://ceres-grafana.dev.monplat.rackspace.net/d/9VfDrq97z/cassandra-overview?viewPanel=24&from=1656000894415&orgId=1&to=1656011678052)

